### PR TITLE
git: attempt at fixing state issue when initializing git worktree

### DIFF
--- a/environment/git.go
+++ b/environment/git.go
@@ -51,8 +51,16 @@ func (env *Environment) InitializeWorktree(ctx context.Context, localRepoPath st
 		return "", err
 	}
 
-	if _, err := os.Stat(worktreePath); err == nil {
-		return worktreePath, nil
+	if _, err := os.Stat(worktreePath); err != nil {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		slog.Info("Initializing local remote", "local-repo-path", localRepoPath, "container-use-repo-path", cuRepoPath)
+		_, err = runGitCommand(ctx, localRepoPath, "clone", "--bare", localRepoPath, cuRepoPath)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	slog.Info("Initializing worktree", "container-id", env.ID, "container-name", env.Name, "id", env.ID)


### PR DESCRIPTION
I have seen one instance of git worktree initialization errors after the `66d2607` commit.

Looking at the code, this could be a missing code path, but I am unable to test this fix without a repro.