### PR TITLE
Fix install target by silencing make find-path output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ find-path:
 
 .PHONY: install
 install: build
-	@DEST=$$(make find-path | tail -n 1); \
+	@DEST=$$(make -s find-path | tail -n 1); \
 	if [ -z "$$DEST" ]; then \
 		echo "No writable directory found in \$PATH"; exit 1; \
 	fi; \


### PR DESCRIPTION
When trying to build `cu` with the following command I get the following error.

```
make install && hash -r
[+] Building 46.3s (11/11) FINISHED                                                                                                    docker:default
 => [internal] load build definition from Dockerfile                                                                                             0.0s
 => => transferring dockerfile: 359B                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/golang:latest                                                                                 1.2s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                0.0s
 => => transferring context: 83B                                                                                                                 0.0s
 => [builder 1/4] FROM docker.io/library/golang:latest@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6                  31.6s
 => => resolve docker.io/library/golang:latest@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6                           0.0s
 => => sha256:f12e54bb499d680e97c49a51f41a2184cc18e6dfdd3d9455d4b8c4a3f68bf69d 2.32kB / 2.32kB                                                   0.0s
 => => sha256:3e6b9d1a95114e19f12262a4e8a59ad1d1a10ca7b82108adcf0605a200294964 48.49MB / 48.49MB                                                11.4s
 => => sha256:37927ed901b1b2608b72796c6881bf645480268eca4ac9a37b9219e050bb4d84 24.02MB / 24.02MB                                                17.3s
 => => sha256:79b2f47ad4443652b9b5cc81a95ede249fd976310efdbee159f29638783778c0 64.40MB / 64.40MB                                                13.9s
 => => sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6 9.74kB / 9.74kB                                                   0.0s
 => => sha256:cafc6a4d857ea56db48f23b23b658d7794bc1e0c7c37b4d0a9e361d67b1805d6 2.80kB / 2.80kB                                                   0.0s
 => => extracting sha256:3e6b9d1a95114e19f12262a4e8a59ad1d1a10ca7b82108adcf0605a200294964                                                        0.7s
 => => sha256:2da67214e06f8425ee4891300ec3c7c55732299c96d214949d63865219f82e6a 92.34MB / 92.34MB                                                24.6s
 => => sha256:92b00dc8dfbaa6cd7e39d09d4f1c726259b4d9a29c697192955da032f472d642 78.98MB / 78.98MB                                                29.8s
 => => extracting sha256:37927ed901b1b2608b72796c6881bf645480268eca4ac9a37b9219e050bb4d84                                                        0.2s
 => => sha256:9835ef05ddecc03faf2677be6f13eb874a74a129f137dcb27dd5a4cc595580e8 126B / 126B                                                      17.6s
 => => extracting sha256:79b2f47ad4443652b9b5cc81a95ede249fd976310efdbee159f29638783778c0                                                        0.9s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                        17.8s
 => => extracting sha256:2da67214e06f8425ee4891300ec3c7c55732299c96d214949d63865219f82e6a                                                        1.0s
 => => extracting sha256:92b00dc8dfbaa6cd7e39d09d4f1c726259b4d9a29c697192955da032f472d642                                                        1.6s
 => => extracting sha256:9835ef05ddecc03faf2677be6f13eb874a74a129f137dcb27dd5a4cc595580e8                                                        0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                        0.0s
 => [internal] load build context                                                                                                                0.0s
 => => transferring context: 86.68kB                                                                                                             0.0s
 => [builder 2/4] WORKDIR /w                                                                                                                     0.3s
 => [builder 3/4] COPY . .                                                                                                                       0.0s
 => [builder 4/4] RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go build -o /tmp/cu ./cmd/cu        13.0s
 => [stage-1 1/1] COPY --from=builder /tmp/cu .                                                                                                  0.0s 
 => exporting to client directory                                                                                                                0.0s 
 => => copying files 21.64MB                                                                                                                     0.0s 
cu                                                                                                                                                    
Installing cu to make[1]: Leaving directory '/home/julian/dev/dagger/container-use'...                                                                
mv: cannot move 'cu' to 'make[1]: Leaving directory '\''/home/julian/dev/dagger/container-use'\''/': No such file or directory                        
make: *** [Makefile:29: install] Error 1
```

This fix suppresses makes output so it doesn't pollute the destination string.

Output I get with the change:

```
❯ make install && hash -r
[+] Building 0.4s (10/10) FINISHED                                                                                                     docker:default
 => [internal] load build definition from Dockerfile                                                                                             0.0s
 => => transferring dockerfile: 359B                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/golang:latest                                                                                 0.4s
 => [internal] load .dockerignore                                                                                                                0.0s
 => => transferring context: 83B                                                                                                                 0.0s
 => [builder 1/4] FROM docker.io/library/golang:latest@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6                   0.0s
 => [internal] load build context                                                                                                                0.0s
 => => transferring context: 632B                                                                                                                0.0s
 => CACHED [builder 2/4] WORKDIR /w                                                                                                              0.0s
 => CACHED [builder 3/4] COPY . .                                                                                                                0.0s
 => CACHED [builder 4/4] RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go build -o /tmp/cu ./cmd/cu  0.0s
 => CACHED [stage-1 1/1] COPY --from=builder /tmp/cu .                                                                                           0.0s
 => exporting to client directory                                                                                                                0.0s
 => => copying files 21.64MB                                                                                                                     0.0s
cu
Installing cu to /usr/local/sbin...
❯ cu
MCP server to add container superpowers to your AI agent.

Usage:
  cu [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  list        List environments
  merge       Merges an environment into the current git branch
  stdio       Start stdio server
  terminal    Drop a terminal into an environment
  watch       Watch git log output

Flags:
  -h, --help   help for cu

Use "cu [command] --help" for more information about a command.
```


