### PR TITLE
fix: goose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ extensions:
     cmd: cu
     args:
     - stdio
-    envs: []
+    envs: {}
 ```
 
 ### [Cursor](https://docs.cursor.com/context/model-context-protocol)


### PR DESCRIPTION
With `envs: []` I have the following error:

    $ goose

    thread 'main' panicked at /Users/runner/work/goose/goose/crates/goose-cli/src/session/builder.rs:147:14:
    should load extensions: Failed to deserialize value: invalid type: sequence, expected struct Envs
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

With `envs: {}` this is working fine.