### PR TITLE
Improve the VS Code + Copilot instructions a little.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,28 @@ curl --create-dirs -o .cursor/rules/container-use.mdc https://raw.githubusercont
 
 ### [VSCode](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) / [GitHub Copilot](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-chat-with-mcp)
 
+The result of the instructions above will be to update your VSCode settings with something that looks like this:
+
+```json
+    "mcp": {
+        "servers": {
+            "container-use": {
+                "type": "stdio",
+                "command": "cu",
+                "args": [
+                    "stdio"
+                ]
+            }
+        }
+    }
+```
+
+Once the MCP server is running, you can optionally) update the instructions for copilot using the following:
+
 ```sh
 curl --create-dirs -o .github/copilot-instructions.md https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md
 ```
+
 ### [Kilo Code](https://kilocode.ai/docs/features/mcp/using-mcp-in-kilo-code)
 
 `Kilo Code` allows setting MCP servers at global or project level - chose any as appropriate for your case. The video shows MCP server setting at global level.


### PR DESCRIPTION
Personally, I missed the fact that the titles were hyper-linked until I started to edit the README, adding a little more explicit instructions to help people understand what they need to do.