### PR TITLE
make: better install messages regarding PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,18 @@
-all: build
+all: cu
 
 TARGETPLATFORM ?= local
 
-.PHONY: build
-build:
-	@which docker >/dev/null || ( echo "Please follow instructions to install Docker at https://docs.docker.com/get-started/get-docker/"; exit 1 )
-	@docker build --platform $(TARGETPLATFORM) -o . .
-	@ls cu
+cu:
+	@./hack/build.sh
 
 .PHONY: clean
 clean:
 	rm -f cu
 
-.PHONY: find-path
-find-path:
-	@PREFERRED_DIR="$$HOME/.local/bin"; \
-	if echo "$$PATH" | grep -q "$$PREFERRED_DIR"; then \
-		echo "$$PREFERRED_DIR"; \
-	else \
-		for dir in $$(echo "$$PATH" | tr ':' ' '); do \
-			if [ -w "$$dir" ]; then \
-				echo "$$dir"; \
-				break; \
-			fi; \
-		done; \
-	fi
-
 .PHONY: install
-install: build
-	@DEST=$$(make -s find-path | tail -n 1); \
-	if [ -z "$$DEST" ]; then \
-		echo "No writable directory found in \$PATH"; exit 1; \
-	fi; \
-	echo "Installing cu to $$DEST..."; \
-	mv cu "$$DEST/"
+install:
+	@./hack/install.sh
+
+.PHONY: uninstall
+uninstall:
+	@./hack/uninstall.sh

--- a/README.md
+++ b/README.md
@@ -42,19 +42,21 @@ git clone https://github.com/dagger/container-use.git
 cd container-use
 ```
 
-Build the project:
-
-```sh
-make
-```
-
-This will build the `cu` binary but _NOT_ install it to your `$PATH`. If you want to build and install the binary into your `$PATH`, run:
+Install the `cu` binary:
 
 ```sh
 make install && hash -r
 ```
 
 The `make install` command will put `cu` in your `$PATH`. In order to use it, you will need to restart your terminal or run `hash -r` to refresh your `$PATH` (or equivalent for your shell).
+
+## Building
+
+To build the `cu` binary without installing it to your `$PATH`:
+
+```sh
+make
+```
 
 The build uses the platform you are on by default. If you need to cross-compile you can use the `TARGETPLATFORM` environment variables. For example `TARGETPLATFORM=linux/arm64 make` to build for Raspberry Pi
 or `TARGETPLATFORM=darwin/arm64 make` to build for macOS Apple Silicon.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ It's an open-source MCP server that works as a CLI tool with Claude Code, Cursor
 
 ## Install
 
+First install [Docker](https://docs.docker.com/get-started/get-docker/), then clone this repository:
+
+```sh
+git clone https://github.com/dagger/container-use.git
+cd container-use
+```
+
+Build the project:
+
 ```sh
 make
 ```

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -uoe pipefail
+
+: {$TARGETPLATFORM:-local}
+which docker >/dev/null || ( echo "Please follow instructions to install Docker at https://docs.docker.com/get-started/get-docker/"; exit 1 )
+docker build --platform "$TARGETPLATFORM" -o . .
+ls cu

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trap 'echo -ne "\e[0m"' EXIT
+
+: "${BIN_DIR:=$HOME/.local/bin}"
+BIN_NAME=cu
+BIN_PATH=${BIN_DIR}/${BIN_NAME}
+
+if [[ -z $SHELL ]]; then
+    2>&1 echo "Could not detect your shell."
+    exit 1
+fi
+
+comm=$(ps -o comm= -p $$ | sed 's#.*/##')
+shell=$(echo "$SHELL" | sed 's#.*/##')
+
+# Ensure we're in the same shell as the login shell
+if [[ $comm != $shell ]]; then
+    exec $SHELL --login -- $0 "$@"
+    exit 1
+fi
+
+bashOrZsh=
+if [[ $SHELL == */bash || $SHELL == */zsh ]]; then
+    bashOrZsh=1
+fi
+
+if [[ $BIN_DIR == "$HOME/.local/bin" ]]; then
+    mkdir -p "$BIN_DIR"
+fi
+if [[ ! -w "$BIN_DIR" ]]; then
+    2>&1 echo "$BIN_DIR is not a writable directory"
+	exit 1
+fi
+
+install -p "$BIN_NAME" "$BIN_DIR/"
+
+echo "Installed $BIN_NAME binary to ${BIN_DIR}"
+
+# Simulate an interactive environment by source-ing the user's rcfile.
+rcfile="$HOME/.${shell}rc"
+if [[ -f "$rcfile" ]]; then
+    # do not abort if user's rcfile has errors
+    set +e
+    source "$rcfile"
+    set -e
+fi
+
+if [[ $(command -v "$BIN_NAME") == $BIN_PATH ]]; then
+    # The parent shell's cache may need to be updated.
+    echo -e "You may need to execute the following to refresh your shell's command cache:\n"
+    if [[ -n $bashOrZsh ]] then
+        echo "  hash -r"
+    else
+        echo "  source \"$rcfile\""
+    fi
+    echo
+    exit 0
+fi
+
+dir=$(command -v "$BIN_NAME" | xargs dirname)
+
+if echo "$PATH" | tr : '\n' | grep -qF "${BIN_DIR}"; then
+    warning="$dir is before $BIN_DIR in PATH\n"
+fi
+
+warning=${warning:-"PATH does not contain $BIN_DIR\n"}
+echo -e "\e[38;2;200;100;100m\nYour shell is unable to locate the installed 'cu' binary\nbecause $warning\e[0m"
+echo -e "Execute the following to configure your shell to locate 'cu' in $BIN_DIR:\n\e[33m"
+echo "  echo 'export PATH=\"${BIN_DIR}:\$PATH\"' >> \"$rcfile\""
+echo "  source \"$rcfile\""
+echo -e "\e[0m"

--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${BIN_DIR:=$HOME/.local/bin}"
+
+if [[ ! -f "$BIN_DIR/cu" ]]; then
+    2>&1 echo "Nothing to uninstall at $BIN_DIR/cu"
+	exit 1
+fi
+
+rm -f "${BIN_DIR}/cu"
+echo "Uninstalled cu from $BIN_DIR"


### PR DESCRIPTION
On top of #22

This will provide more targeted guidance when calling `make install`.
Specifically:
- If installation is successful, tell the user they may need to run hash -r
- If the install destination is not in PATH, tell the user how to add it.
- If the install destination is in PATH but has lower precedence than an already
existing binary (such as /usr/bin/cu on macOS) then tell the user how to update
their PATH accordingly.

Also, I moved most of the Makefile logic into hack scripts.