### PR TITLE
cmd/cu: adds show command to help with git show <remote branch>

### DIFF
--- a/cmd/cu/logger.go
+++ b/cmd/cu/logger.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+)
+
+var (
+	logWriter = io.Discard
+)
+
+func parseLogLevel(levelStr string) slog.Level {
+	switch levelStr {
+	case "debug", "DEBUG":
+		return slog.LevelDebug
+	case "info", "INFO":
+		return slog.LevelInfo
+	case "warn", "WARN", "warning", "WARNING":
+		return slog.LevelWarn
+	case "error", "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func setupLogger() error {
+	var writers []io.Writer
+
+	logFile := "/tmp/cu.debug.stderr.log"
+	if v, ok := os.LookupEnv("CU_STDERR_FILE"); ok {
+		logFile = v
+	}
+
+	file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open log file %s: %w", logFile, err)
+	}
+	writers = append(writers, file)
+
+	if len(writers) == 0 {
+		fmt.Fprintf(os.Stderr, "%s Logging disabled. Set CU_STDERR_FILE and CU_LOG_LEVEL environment variables\n", time.Now().Format(time.DateTime))
+	}
+
+	logLevel := parseLogLevel(os.Getenv("CU_LOG_LEVEL"))
+	logWriter = io.MultiWriter(writers...)
+	handler := slog.NewTextHandler(logWriter, &slog.HandlerOptions{
+		Level: logLevel,
+	})
+	slog.SetDefault(slog.New(handler))
+
+	return nil
+}


### PR DESCRIPTION
Related to issue #50.

I want to ignore that there is a remote-local fork under `~/.config`. So I should be able to show the local env, without having to know where it lives on the disk or understand there are 2 forks (mine and cu's).