### PR TITLE
cmd/cu: fixes merge misleading error and exit code

### DIFF
--- a/cmd/cu/merge.go
+++ b/cmd/cu/merge.go
@@ -17,9 +17,10 @@ var mergeCmd = &cobra.Command{
 		env := args[0]
 		// prevent accidental single quotes to mess up command
 		env = strings.Trim(env, "'")
-		cmd := exec.CommandContext(app.Context(), "bash", "-c", fmt.Sprintf("git stash --include-untracked -q && git merge -m 'Merge environment %s' -- %q && ( git stash pop -q 2>/dev/null )", env, "container-use/"+env))
+		cmd := exec.CommandContext(app.Context(), "bash", "-c", fmt.Sprintf("git stash --include-untracked -q && git merge -m 'Merge environment %s' -- %q && ( git stash pop -q 2>/dev/null || true )", env, "container-use/"+env))
 		cmd.Stderr = os.Stderr
 		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
 
 		return cmd.Run()
 	},


### PR DESCRIPTION
Fixes #28 

When there is nothing to merge, no message is written on stdout (it took me some time to realize the changes were already merged).

And when there is nothing to stash, the `stash pop` exit 1, which displays the help for the merge command.

This is misleading and confusing, this fixes it (prints stdout and always exit 0 on `stash pop`, behaves like `stash`).