### PR TITLE
introduce environment.Remote interface to separate out remote/storage concerns from user-local repository concerns

### DIFF
--- a/cmd/cu/delete.go
+++ b/cmd/cu/delete.go
@@ -6,6 +6,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/container-use/environment"
+	"github.com/dagger/container-use/environment/remotes"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,8 @@ var deleteCmd = &cobra.Command{
 			return fmt.Errorf("failed to connect to dagger: %w", err)
 		}
 		defer dag.Close()
-		environment.Initialize(dag)
+		localRemote := remotes.NewLocalRemote(dag)
+		environment.Initialize(dag, localRemote)
 
 		env := environment.Get(envName)
 		if env == nil {

--- a/cmd/cu/delete.go
+++ b/cmd/cu/delete.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"dagger.io/dagger"
@@ -31,6 +32,7 @@ var deleteCmd = &cobra.Command{
 		if env == nil {
 			// Try to open if not in memory
 			var openErr error
+			slog.Info("Opening environment for deletion", "name", envName)
 			env, openErr = environment.Open(ctx, "delete environment", ".", envName)
 			if openErr != nil {
 				return fmt.Errorf("environment '%s' not found: %w", envName, openErr)

--- a/cmd/cu/main.go
+++ b/cmd/cu/main.go
@@ -13,6 +13,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/container-use/environment"
+	"github.com/dagger/container-use/environment/remotes"
 	"github.com/dagger/container-use/mcpserver"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +50,8 @@ var (
 			}
 			defer dag.Close()
 
-			environment.Initialize(dag)
+			localRemote := remotes.NewLocalRemote(dag)
+			environment.Initialize(dag, localRemote)
 			return mcpserver.RunStdioServer(ctx)
 		},
 	}

--- a/cmd/cu/terminal.go
+++ b/cmd/cu/terminal.go
@@ -10,6 +10,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/container-use/environment"
+	"github.com/dagger/container-use/environment/remotes"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +41,8 @@ var terminalCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		defer dag.Close()
-		environment.Initialize(dag)
+		localRemote := remotes.NewLocalRemote(dag)
+		environment.Initialize(dag, localRemote)
 
 		env, err := environment.Open(ctx, "opening terminal", ".", args[0])
 		if err != nil {

--- a/cmd/cu/terminal.go
+++ b/cmd/cu/terminal.go
@@ -44,6 +44,7 @@ var terminalCmd = &cobra.Command{
 		localRemote := remotes.NewLocalRemote(dag)
 		environment.Initialize(dag, localRemote)
 
+		slog.Info("Opening environment for terminal access", "name", args[0])
 		env, err := environment.Open(ctx, "opening terminal", ".", args[0])
 		if err != nil {
 			return err

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -74,10 +74,9 @@ func Initialize(client *dagger.Client) error {
 }
 
 type Environment struct {
-	ID       string `json:"-"`
-	Name     string `json:"-"`
-	Source   string `json:"-"`
-	Worktree string `json:"-"`
+	ID     string `json:"-"`
+	Name   string `json:"-"`
+	Source string `json:"-"`
 
 	Instructions  string   `json:"-"`
 	Workdir       string   `json:"workdir"`
@@ -154,11 +153,6 @@ func Create(ctx context.Context, explanation, source, name string) (*Environment
 			return nil, err
 		}
 	}
-	worktreePath, err := env.GetWorktreePath()
-	if err != nil {
-		return nil, err
-	}
-	env.Worktree = worktreePath
 
 	container, err := env.buildBase(ctx)
 	if err != nil {
@@ -191,11 +185,6 @@ func Open(ctx context.Context, explanation, source, id string) (*Environment, er
 	if err := env.SetupTrackingBranch(ctx, source); err != nil {
 		return nil, fmt.Errorf("failed setting up tracking branch: %w", err)
 	}
-	worktreePath, err := env.GetWorktreePath()
-	if err != nil {
-		return nil, err
-	}
-	env.Worktree = worktreePath
 
 	localRepoPath, err := filepath.Abs(source)
 	if err != nil {

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -204,7 +204,7 @@ func Create(ctx context.Context, explanation, source, name string) (*Environment
 	}
 	environments[env.ID] = env
 
-	if err := env.PropogateToTrackedBranch(ctx, "Init env "+name, explanation); err != nil {
+	if err := env.PropagateToTrackedBranch(ctx, "Init env "+name, explanation); err != nil {
 		return nil, fmt.Errorf("failed to propagate to tracking branch: %w", err)
 	}
 
@@ -326,7 +326,7 @@ func (env *Environment) Update(ctx context.Context, explanation, instructions, b
 		return err
 	}
 
-	return env.PropogateToTrackedBranch(ctx, "Update environment "+env.Name, explanation)
+	return env.PropagateToTrackedBranch(ctx, "Update environment "+env.Name, explanation)
 }
 
 func Get(idOrName string) *Environment {
@@ -376,7 +376,7 @@ func (env *Environment) Run(ctx context.Context, explanation, command, shell str
 		return "", err
 	}
 
-	if err := env.PropogateToTrackedBranch(ctx, "Run "+command, explanation); err != nil {
+	if err := env.PropagateToTrackedBranch(ctx, "Run "+command, explanation); err != nil {
 		return "", fmt.Errorf("failed to propagate to tracking branch: %w", err)
 	}
 
@@ -484,7 +484,7 @@ func (env *Environment) Revert(ctx context.Context, explanation string, version 
 	if err := env.apply(ctx, "Revert to "+revision.Name, explanation, "", revision.container); err != nil {
 		return err
 	}
-	return env.PropogateToTrackedBranch(ctx, "Revert to "+revision.Name, explanation)
+	return env.PropagateToTrackedBranch(ctx, "Revert to "+revision.Name, explanation)
 }
 
 func (env *Environment) Fork(ctx context.Context, explanation, name string, version *Version) (*Environment, error) {

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -174,18 +174,18 @@ func Create(ctx context.Context, explanation, source, name string) (*Environment
 		}
 	}
 
-	// // Generate patch from uncommitted changes in the source repo
-	// patch, err := env.GeneratePatch(ctx)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("failed to generate patch: %w", err)
-	// }
+	// Generate patch from uncommitted changes in the source repo
+	patch, err := env.GeneratePatch(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate patch: %w", err)
+	}
 
-	// // Apply the patch if there are any changes
-	// if patch != "" {
-	// 	if err := storage.Patch(env, patch); err != nil {
-	// 		return nil, fmt.Errorf("failed to apply patch: %w", err)
-	// 	}
-	// }
+	// Apply the patch if there are any changes
+	if patch != "" {
+		if err := storage.Patch(env, patch); err != nil {
+			return nil, fmt.Errorf("failed to apply patch: %w", err)
+		}
+	}
 
 	container, err := env.buildBase(ctx)
 	if err != nil {

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -41,7 +41,7 @@ func (s *Environment) FileWrite(ctx context.Context, explanation, targetFile, co
 		return fmt.Errorf("failed applying file write, skipping git propogation: %w", err)
 	}
 
-	return s.PropagateToTrackedBranch(ctx, "Write "+targetFile, explanation)
+	return storage.Save(s, "Write "+targetFile, explanation)
 }
 
 func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile string) error {
@@ -50,7 +50,7 @@ func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile st
 		return err
 	}
 
-	return s.PropagateToTrackedBranch(ctx, "Delete "+targetFile, explanation)
+	return storage.Save(s, "Delete "+targetFile, explanation)
 }
 
 func (s *Environment) FileList(ctx context.Context, path string) (string, error) {
@@ -84,7 +84,7 @@ func (s *Environment) Upload(ctx context.Context, explanation, source string, ta
 		return err
 	}
 
-	return s.PropagateToTrackedBranch(ctx, "Upload "+source+" to "+target, explanation)
+	return storage.Save(s, "Upload "+source+" to "+target, explanation)
 }
 
 func (s *Environment) Download(ctx context.Context, source string, target string) error {

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -41,7 +41,7 @@ func (s *Environment) FileWrite(ctx context.Context, explanation, targetFile, co
 		return fmt.Errorf("failed applying file write, skipping git propogation: %w", err)
 	}
 
-	return s.PropogateToTrackedBranch(ctx, "Write "+targetFile, explanation)
+	return s.PropagateToTrackedBranch(ctx, "Write "+targetFile, explanation)
 }
 
 func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile string) error {
@@ -50,7 +50,7 @@ func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile st
 		return err
 	}
 
-	return s.PropogateToTrackedBranch(ctx, "Delete "+targetFile, explanation)
+	return s.PropagateToTrackedBranch(ctx, "Delete "+targetFile, explanation)
 }
 
 func (s *Environment) FileList(ctx context.Context, path string) (string, error) {
@@ -84,7 +84,7 @@ func (s *Environment) Upload(ctx context.Context, explanation, source string, ta
 		return err
 	}
 
-	return s.PropogateToTrackedBranch(ctx, "Upload "+source+" to "+target, explanation)
+	return s.PropagateToTrackedBranch(ctx, "Upload "+source+" to "+target, explanation)
 }
 
 func (s *Environment) Download(ctx context.Context, source string, target string) error {

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -41,7 +41,7 @@ func (s *Environment) FileWrite(ctx context.Context, explanation, targetFile, co
 		return fmt.Errorf("failed applying file write, skipping git propogation: %w", err)
 	}
 
-	return s.propagateToWorktree(ctx, "Write "+targetFile, explanation)
+	return s.PropogateToTrackedBranch(ctx, "Write "+targetFile, explanation)
 }
 
 func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile string) error {
@@ -50,7 +50,7 @@ func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile st
 		return err
 	}
 
-	return s.propagateToWorktree(ctx, "Delete "+targetFile, explanation)
+	return s.PropogateToTrackedBranch(ctx, "Delete "+targetFile, explanation)
 }
 
 func (s *Environment) FileList(ctx context.Context, path string) (string, error) {
@@ -84,7 +84,7 @@ func (s *Environment) Upload(ctx context.Context, explanation, source string, ta
 		return err
 	}
 
-	return s.propagateToWorktree(ctx, "Upload "+source+" to "+target, explanation)
+	return s.PropogateToTrackedBranch(ctx, "Upload "+source+" to "+target, explanation)
 }
 
 func (s *Environment) Download(ctx context.Context, source string, target string) error {

--- a/environment/git.go
+++ b/environment/git.go
@@ -9,10 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
-	"dagger.io/dagger"
 	"github.com/mitchellh/go-homedir"
 )
 
@@ -22,67 +20,43 @@ const (
 	gitNotesStateRef   = "container-use-state"
 )
 
-const maxFileSizeForTextCheck = 10 * 1024 * 1024
-
 func (env *Environment) SetupTrackingBranch(ctx context.Context, localRepoPath string) error {
 	localRepoPath, err := filepath.Abs(localRepoPath)
 	if err != nil {
 		return err
 	}
 
-	storage, err := env.initializeStorage(ctx, localRepoPath)
-	if err != nil {
+	if err := env.createTrackingBranch(ctx, localRepoPath); err != nil {
 		return err
-	}
-
-	if err := env.createTrackingBranch(ctx, localRepoPath, storage); err != nil {
-		return err
-	}
-
-	if err := storage.applyUncommittedChanges(ctx, localRepoPath); err != nil {
-		return fmt.Errorf("failed to apply uncommitted changes: %w", err)
 	}
 
 	return nil
 }
 
-func (env *Environment) createTrackingBranch(ctx context.Context, localRepoPath string, storage *Storage) error {
+func (env *Environment) createTrackingBranch(ctx context.Context, localRepoPath string) error {
 	slog.Info("Setting up tracking branch", "environment", env.ID, "branch", env.ID)
-
-	// Fetch current complete storage state
-	_, err := runGitCommand(ctx, localRepoPath, "fetch", containerUseRemote)
-	if err != nil {
-		return err
-	}
 
 	// Push current branch to storage to establish the tracking branch
 	currentBranch, err := runGitCommand(ctx, localRepoPath, "branch", "--show-current")
 	if err != nil {
 		return err
 	}
+
 	currentBranch = strings.TrimSpace(currentBranch)
+	if currentBranch == "" {
+		return fmt.Errorf("no current branch found")
+	}
 
-	_, err = runGitCommand(ctx, localRepoPath, "push", containerUseRemote, "--force", currentBranch)
+	// Create the tracking branch by pushing to storage
+	_, err = runGitCommand(ctx, localRepoPath, "push", containerUseRemote, fmt.Sprintf("%s:%s", currentBranch, env.ID))
 	if err != nil {
 		return err
 	}
 
-	// Create storage worktree for this tracking branch
-	if err := storage.createWorktree(ctx, currentBranch); err != nil {
-		return err
-	}
-
-	// Establish the tracking branch in source repo
-	if err := env.fetchStorage(ctx, localRepoPath); err != nil {
-		return err
-	}
-
-	_, err = runGitCommand(ctx, localRepoPath, "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", env.ID))
+	// Set up the tracking branch locally
+	_, err = runGitCommand(ctx, localRepoPath, "branch", "--track", env.ID, fmt.Sprintf("%s/%s", containerUseRemote, env.ID))
 	if err != nil {
-		_, err = runGitCommand(ctx, localRepoPath, "branch", "--track", env.ID, fmt.Sprintf("%s/%s", containerUseRemote, env.ID))
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	return nil
@@ -91,31 +65,15 @@ func (env *Environment) createTrackingBranch(ctx context.Context, localRepoPath 
 func (env *Environment) PropagateToTrackedBranch(ctx context.Context, name, explanation string) error {
 	slog.Info("Propagating to tracked environment branch", "environment", env.ID, "branch", env.ID)
 
-	localRepoPath, err := filepath.Abs(env.Source)
+	localRepoPath, err := filepath.Abs(env.source)
 	if err != nil {
 		return err
 	}
 
-	storage, err := env.initializeStorage(ctx, localRepoPath)
-	if err != nil {
+	if err := storage.Save(env, name, explanation); err != nil {
 		return err
 	}
 
-	if err := storage.save(ctx, env); err != nil {
-		return err
-	}
-
-	// Commit changes in storage layer
-	if err := storage.commitChanges(ctx, name, explanation); err != nil {
-		return fmt.Errorf("failed to commit to storage: %w", err)
-	}
-
-	// Commit state to tracking branch
-	if err := storage.commitStateToNotes(ctx, env); err != nil {
-		return fmt.Errorf("failed to add notes to tracking branch: %w", err)
-	}
-
-	// Fetch tracking branch from storage to source repo (needed for notes propagation)
 	if err := env.fetchStorage(ctx, localRepoPath); err != nil {
 		return err
 	}
@@ -133,147 +91,31 @@ func (env *Environment) PropagateToTrackedBranch(ctx context.Context, name, expl
 }
 
 func (env *Environment) DeleteTrackingBranch() error {
-	// Clean up storage layer
-	if err := env.deleteStorage(); err != nil {
-		return err
-	}
+	slog.Info("Deleting tracking branch", "environment", env.ID, "branch", env.ID)
 
-	// Remove tracking branch from source repo
-	localRepoPath, err := filepath.Abs(env.Source)
+	localRepoPath, err := filepath.Abs(env.source)
 	if err != nil {
 		return err
 	}
 
-	if _, err = runGitCommand(context.Background(), localRepoPath, "remote", "prune", containerUseRemote); err != nil {
-		slog.Error("Failed to prune container-use remote", "repo", localRepoPath, "err", err)
-		return err
+	ctx := context.Background()
+
+	// Delete the remote tracking branch
+	_, err = runGitCommand(ctx, localRepoPath, "push", containerUseRemote, "--delete", env.ID)
+	if err != nil {
+		slog.Warn("Failed to delete remote tracking branch", "err", err)
 	}
 
-	return nil
+	// Delete local tracking branch
+	_, err = runGitCommand(ctx, localRepoPath, "branch", "-D", env.ID)
+	if err != nil {
+		slog.Warn("Failed to delete local tracking branch", "err", err)
+	}
+
+	return env.deleteStorage()
 }
 
-// This initial storage impl uses a local file:// remote and worktrees to provide storage to the container-use environment.
-// We have yet to define an interface around this, but it should be swappable for remote-remotes in the future, or impls that put container state somewhere other than git notes.
-type Storage struct {
-	repoPath     string
-	worktreePath string
-	Branch       string
-}
-
-func (env *Environment) initializeStorage(ctx context.Context, localRepoPath string) (*Storage, error) {
-	cuRepoPath, err := initializeLocalRemote(ctx, localRepoPath)
-	if err != nil {
-		return nil, err
-	}
-
-	worktreePath, err := homedir.Expand(fmt.Sprintf("~/.config/container-use/worktrees/%s", env.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	return &Storage{
-		repoPath:     cuRepoPath,
-		worktreePath: worktreePath,
-		Branch:       env.ID,
-	}, nil
-}
-
-func (storage *Storage) createWorktree(ctx context.Context, sourceBranch string) error {
-	if _, err := os.Stat(storage.worktreePath); err == nil {
-		return nil
-	}
-
-	// Create worktree from storage repo
-	_, err := runGitCommand(ctx, storage.repoPath, "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", filepath.Base(storage.worktreePath)))
-	if err != nil {
-		_, err = runGitCommand(ctx, storage.repoPath, "worktree", "add", "-b", storage.Branch, storage.worktreePath, sourceBranch)
-		if err != nil {
-			return err
-		}
-	} else {
-		_, err = runGitCommand(ctx, storage.repoPath, "worktree", "add", storage.worktreePath, storage.Branch)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (storage *Storage) commitChanges(ctx context.Context, name, explanation string) error {
-	status, err := runGitCommand(ctx, storage.worktreePath, "status", "--porcelain")
-	if err != nil {
-		return err
-	}
-
-	if strings.TrimSpace(status) == "" {
-		return nil
-	}
-
-	if err := addNonBinaryFiles(ctx, storage.worktreePath); err != nil {
-		return err
-	}
-
-	commitMsg := fmt.Sprintf("%s\n\n%s", name, explanation)
-	_, err = runGitCommand(ctx, storage.worktreePath, "commit", "-m", commitMsg)
-	return err
-}
-
-func (storage *Storage) Workdir() *dagger.Directory {
-	return dag.Host().Directory(storage.worktreePath)
-}
-
-func (storage *Storage) save(ctx context.Context, env *Environment) error {
-	_, err := env.container.Directory(env.Workdir).Export(
-		ctx,
-		storage.worktreePath,
-		dagger.DirectoryExportOpts{Wipe: true},
-	)
-	if err != nil {
-		return err
-	}
-
-	cfg := filepath.Join(storage.worktreePath, ".container-use")
-	if err := os.MkdirAll(cfg, 0755); err != nil {
-		return err
-	}
-
-	if err := os.WriteFile(filepath.Join(cfg, "AGENT.md"), []byte(env.Instructions), 0644); err != nil {
-		return err
-	}
-
-	envState, err := json.MarshalIndent(env, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	if err := os.WriteFile(filepath.Join(cfg, "environment.json"), envState, 0644); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (storage *Storage) load(env *Environment) error {
-	cfg := filepath.Join(storage.worktreePath, ".container-use")
-
-	instructions, err := os.ReadFile(filepath.Join(cfg, "AGENT.md"))
-	if err != nil {
-		return err
-	}
-	env.Instructions = string(instructions)
-
-	envState, err := os.ReadFile(filepath.Join(cfg, "environment.json"))
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(envState, env); err != nil {
-		return err
-	}
-
-	return nil
-}
-
+// this is violently breaking the remote abstraction right now
 func (env *Environment) deleteStorage() error {
 	// Delete worktree
 	worktreePath, err := env.GetWorktreePath()
@@ -286,77 +128,109 @@ func (env *Environment) deleteStorage() error {
 		return err
 	}
 
-	// Clean up storage repo
-	localRepoPath, err := filepath.Abs(env.Source)
-	if err != nil {
-		return err
-	}
-	repoName := filepath.Base(localRepoPath)
-	cuRepoPath, err := getRepoPath(repoName)
-	if err != nil {
-		return err
-	}
-
-	slog.Info("Pruning storage worktrees", "repo", cuRepoPath)
-	if _, err = runGitCommand(context.Background(), cuRepoPath, "worktree", "prune"); err != nil {
-		slog.Error("Failed to prune worktrees", "repo", cuRepoPath, "err", err)
-		return err
-	}
-
-	slog.Info("Deleting storage branch", "repo", cuRepoPath, "branch", env.ID)
-	if _, err = runGitCommand(context.Background(), cuRepoPath, "branch", "-D", env.ID); err != nil {
-		slog.Error("Failed to delete storage branch", "repo", cuRepoPath, "branch", env.ID, "err", err)
-		return err
+	// Delete the storage repository ()
+	repoPath := storage.RemoteUrl(filepath.Base(env.source))
+	if strings.HasPrefix(repoPath, "file://") {
+		repoPath = repoPath[7:] // Remove file:// prefix
+		slog.Info("Deleting storage repository", "path", repoPath)
+		if err := os.RemoveAll(repoPath); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func getRepoPath(repoName string) (string, error) {
-	return homedir.Expand(fmt.Sprintf("~/.config/container-use/repos/%s", filepath.Base(repoName)))
-}
-
-func initializeLocalRemote(ctx context.Context, localRepoPath string) (string, error) {
-	localRepoPath, err := filepath.Abs(localRepoPath)
-	if err != nil {
-		return "", err
+func (env *Environment) fetchGitNotes(ctx context.Context, ref string) error {
+	fullRef := fmt.Sprintf("refs/notes/%s", ref)
+	fetch := func() error {
+		_, err := runGitCommand(ctx, env.source, "fetch", containerUseRemote, fullRef+":"+fullRef)
+		return err
 	}
 
-	repoName := filepath.Base(localRepoPath)
-	cuRepoPath, err := getRepoPath(repoName)
-	if err != nil {
-		return "", err
-	}
-
-	if _, err := os.Stat(cuRepoPath); err != nil {
-		if !os.IsNotExist(err) {
-			return "", err
-		}
-
-		slog.Info("Initializing storage repository", "source", localRepoPath, "storage", cuRepoPath)
-		_, err = runGitCommand(ctx, localRepoPath, "clone", "--bare", localRepoPath, cuRepoPath)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	// Set up remote in source repo pointing to storage
-	existingURL, err := runGitCommand(ctx, localRepoPath, "remote", "get-url", containerUseRemote)
-	if err != nil {
-		_, err = runGitCommand(ctx, localRepoPath, "remote", "add", containerUseRemote, cuRepoPath)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		existingURL = strings.TrimSpace(existingURL)
-		if existingURL != cuRepoPath {
-			_, err = runGitCommand(ctx, localRepoPath, "remote", "set-url", containerUseRemote, cuRepoPath)
-			if err != nil {
-				return "", err
+	if err := fetch(); err != nil {
+		if strings.Contains(err.Error(), "[rejected]") {
+			if _, err := runGitCommand(ctx, env.source, "update-ref", "-d", fullRef); err == nil {
+				return fetch()
 			}
 		}
+		return err
 	}
-	return cuRepoPath, nil
+	return nil
+}
+
+func (env *Environment) addGitNote(ctx context.Context, note string) error {
+	return storage.Note(env, note)
+}
+
+func StateFromCommit(ctx context.Context, localRepoPath, commitHash string) (History, error) {
+	notes, err := runGitCommand(ctx, localRepoPath, "notes", "--ref", gitNotesStateRef, "show", commitHash)
+	if err != nil {
+		return nil, err
+	}
+
+	var history History
+	if err := json.Unmarshal([]byte(notes), &history); err != nil {
+		return nil, err
+	}
+
+	return history, nil
+}
+
+func (env *Environment) loadStateFromNotes(ctx context.Context, localRepoPath string) error {
+	history, err := StateFromCommit(ctx, localRepoPath, "HEAD")
+	if err != nil {
+		return err
+	}
+	env.History = history
+	return nil
+}
+
+func (env *Environment) GeneratePatch(ctx context.Context) (string, error) {
+	localRepoPath, err := filepath.Abs(env.source)
+	if err != nil {
+		return "", err
+	}
+
+	status, err := runGitCommand(ctx, localRepoPath, "status", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+
+	slog.Debug("Git status output", "status", status)
+
+	if strings.TrimSpace(status) == "" {
+		slog.Debug("No changes detected, returning empty patch")
+		return "", nil
+	}
+
+	slog.Info("Generating patch from uncommitted changes")
+
+	// Check if repository has any commits
+	_, err = runGitCommand(ctx, localRepoPath, "rev-parse", "HEAD")
+	if err != nil {
+		slog.Debug("No HEAD commit found, skipping diff generation")
+		return "", nil
+	}
+
+	// Generate diff patch for tracked changes
+	patch, err := runGitCommand(ctx, localRepoPath, "diff", "HEAD")
+	if err != nil {
+		return "", err
+	}
+
+	slog.Debug("Generated diff patch", "patch_length", len(patch))
+	return patch, nil
+}
+
+func (env *Environment) fetchStorage(ctx context.Context, localRepoPath string) error {
+	slog.Info("Fetching tracking branch from storage to source repository")
+	_, err := runGitCommand(ctx, localRepoPath, "fetch", containerUseRemote, env.ID)
+	return err
+}
+
+func (env *Environment) GetWorktreePath() (string, error) {
+	return homedir.Expand(fmt.Sprintf("~/.config/container-use/worktrees/%s", env.ID))
 }
 
 func runGitCommand(ctx context.Context, dir string, args ...string) (out string, rerr error) {
@@ -379,315 +253,4 @@ func runGitCommand(ctx context.Context, dir string, args ...string) (out string,
 	}
 
 	return string(output), nil
-}
-
-func (env *Environment) fetchGitNotes(ctx context.Context, ref string) error {
-	fullRef := fmt.Sprintf("refs/notes/%s", ref)
-	fetch := func() error {
-		_, err := runGitCommand(ctx, env.Source, "fetch", containerUseRemote, fullRef+":"+fullRef)
-		return err
-	}
-
-	if err := fetch(); err != nil {
-		if strings.Contains(err.Error(), "[rejected]") {
-			if _, err := runGitCommand(ctx, env.Source, "update-ref", "-d", fullRef); err == nil {
-				return fetch()
-			}
-		}
-		return err
-	}
-	return nil
-}
-
-func (storage *Storage) commitStateToNotes(ctx context.Context, env *Environment) error {
-	buff, err := json.MarshalIndent(env.History, "", "  ")
-	if err != nil {
-		return err
-	}
-	f, err := os.CreateTemp(os.TempDir(), ".container-use-git-notes-*")
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if _, err := f.Write(buff); err != nil {
-		return err
-	}
-
-	_, err = runGitCommand(ctx, storage.worktreePath, "notes", "--ref", gitNotesStateRef, "add", "-f", "-F", f.Name())
-	return err
-}
-
-func (storage *Storage) addGitNote(ctx context.Context, note string) error {
-	_, err := runGitCommand(ctx, storage.worktreePath, "notes", "--ref", gitNotesLogRef, "append", "-m", note)
-	return err
-}
-
-func (env *Environment) addGitNote(ctx context.Context, note string) error {
-	localRepoPath, err := filepath.Abs(env.Source)
-	if err != nil {
-		return err
-	}
-
-	storage, err := env.initializeStorage(ctx, localRepoPath)
-	if err != nil {
-		return err
-	}
-
-	if err := storage.addGitNote(ctx, note); err != nil {
-		return err
-	}
-	return env.fetchGitNotes(ctx, gitNotesLogRef)
-}
-
-func StateFromCommit(ctx context.Context, repoDir, commit string) (History, error) {
-	buff, err := runGitCommand(ctx, repoDir, "notes", "--ref", gitNotesStateRef, "show")
-	if err != nil {
-		return nil, err
-	}
-
-	var history History
-	if err := json.Unmarshal([]byte(buff), &history); err != nil {
-		return nil, err
-	}
-	return history, nil
-}
-
-func (env *Environment) loadStateFromNotes(ctx context.Context, worktreePath string) error {
-	buff, err := runGitCommand(ctx, worktreePath, "notes", "--ref", gitNotesStateRef, "show")
-	if err != nil {
-		if strings.Contains(err.Error(), "no note found") {
-			return nil
-		}
-		return err
-	}
-	return json.Unmarshal([]byte(buff), &env.History)
-}
-
-func (env *Environment) fetchStorage(ctx context.Context, localRepoPath string) error {
-	slog.Info("Fetching tracking branch from storage to source repository")
-	_, err := runGitCommand(ctx, localRepoPath, "fetch", containerUseRemote, env.ID)
-	return err
-}
-
-func (storage *Storage) applyUncommittedChanges(ctx context.Context, localRepoPath string) error {
-	status, err := runGitCommand(ctx, localRepoPath, "status", "--porcelain")
-	if err != nil {
-		return err
-	}
-
-	if strings.TrimSpace(status) == "" {
-		return nil
-	}
-
-	slog.Info("Applying uncommitted changes to tracked branch")
-
-	patch, err := runGitCommand(ctx, localRepoPath, "diff", "HEAD")
-	if err != nil {
-		return err
-	}
-
-	if strings.TrimSpace(patch) != "" {
-		cmd := exec.Command("git", "apply")
-		cmd.Dir = storage.worktreePath
-		cmd.Stdin = strings.NewReader(patch)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to apply patch: %w", err)
-		}
-	}
-
-	untrackedFiles, err := runGitCommand(ctx, localRepoPath, "ls-files", "--others", "--exclude-standard")
-	if err != nil {
-		return err
-	}
-
-	for _, file := range strings.Split(strings.TrimSpace(untrackedFiles), "\n") {
-		if file == "" {
-			continue
-		}
-		srcPath := filepath.Join(localRepoPath, file)
-		destPath := filepath.Join(storage.worktreePath, file)
-
-		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-			return err
-		}
-
-		if err := exec.Command("cp", "-r", srcPath, destPath).Run(); err != nil {
-			return fmt.Errorf("failed to copy untracked file %s: %w", file, err)
-		}
-	}
-
-	return storage.commitChanges(ctx, "Copy uncommitted changes", "Applied uncommitted changes from local repository")
-}
-
-func addNonBinaryFiles(ctx context.Context, worktreePath string) error {
-	statusOutput, err := runGitCommand(ctx, worktreePath, "status", "--porcelain")
-	if err != nil {
-		return err
-	}
-
-	lines := strings.Split(strings.TrimSpace(statusOutput), "\n")
-
-	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-		if len(line) < 3 {
-			continue
-		}
-
-		indexStatus := line[0]
-		workTreeStatus := line[1]
-		fileName := strings.TrimSpace(line[2:])
-		if fileName == "" {
-			continue
-		}
-
-		if shouldSkipFile(fileName) {
-			continue
-		}
-
-		switch {
-		case indexStatus == '?' && workTreeStatus == '?':
-			if strings.HasSuffix(fileName, "/") {
-				dirName := strings.TrimSuffix(fileName, "/")
-				if err := addFilesFromUntrackedDirectory(ctx, worktreePath, dirName); err != nil {
-					return err
-				}
-			} else {
-				if !isBinaryFile(worktreePath, fileName) {
-					_, err = runGitCommand(ctx, worktreePath, "add", fileName)
-					if err != nil {
-						return err
-					}
-				}
-			}
-		case indexStatus == 'A':
-			continue
-		case indexStatus == 'D' || workTreeStatus == 'D':
-			_, err = runGitCommand(ctx, worktreePath, "add", fileName)
-			if err != nil {
-				return err
-			}
-		default:
-			if !isBinaryFile(worktreePath, fileName) {
-				_, err = runGitCommand(ctx, worktreePath, "add", fileName)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func shouldSkipFile(fileName string) bool {
-	skipExtensions := []string{
-		".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz",
-		".zip", ".rar", ".7z", ".gz", ".bz2", ".xz",
-		".exe", ".bin", ".dmg", ".pkg", ".msi",
-		".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".svg",
-		".mp3", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv",
-		".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
-		".so", ".dylib", ".dll", ".a", ".lib",
-	}
-
-	lowerName := strings.ToLower(fileName)
-	for _, ext := range skipExtensions {
-		if strings.HasSuffix(lowerName, ext) {
-			return true
-		}
-	}
-
-	skipPatterns := []string{
-		"node_modules/", ".git/", "__pycache__/", ".DS_Store",
-		"venv/", ".venv/", "env/", ".env/",
-		"target/", "build/", "dist/", ".next/",
-		"*.tmp", "*.temp", "*.cache", "*.log",
-	}
-
-	for _, pattern := range skipPatterns {
-		if strings.Contains(lowerName, strings.ToLower(pattern)) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func addFilesFromUntrackedDirectory(ctx context.Context, worktreePath, dirName string) error {
-	dirPath := filepath.Join(worktreePath, dirName)
-
-	return filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		relPath, err := filepath.Rel(worktreePath, path)
-		if err != nil {
-			return err
-		}
-
-		if info.IsDir() {
-			if shouldSkipFile(relPath + "/") {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if shouldSkipFile(relPath) {
-			return nil
-		}
-
-		if !isBinaryFile(worktreePath, relPath) {
-			_, err = runGitCommand(ctx, worktreePath, "add", relPath)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-}
-
-func isBinaryFile(worktreePath, fileName string) bool {
-	fullPath := filepath.Join(worktreePath, fileName)
-
-	stat, err := os.Stat(fullPath)
-	if err != nil {
-		return true
-	}
-
-	if stat.IsDir() {
-		return false
-	}
-
-	if stat.Size() > maxFileSizeForTextCheck {
-		return true
-	}
-
-	file, err := os.Open(fullPath)
-	if err != nil {
-		slog.Error("Error opening file", "err", err)
-		return true
-	}
-	defer file.Close()
-
-	buffer := make([]byte, 8000)
-	n, err := file.Read(buffer)
-	if err != nil && n == 0 {
-		return true
-	}
-
-	buffer = buffer[:n]
-	if slices.Contains(buffer, 0) {
-		return true
-	}
-
-	return false
-}
-
-// Backward compatibility methods
-func (env *Environment) GetWorktreePath() (string, error) {
-	return homedir.Expand(fmt.Sprintf("~/.config/container-use/worktrees/%s", env.ID))
 }

--- a/environment/remotes/local.go
+++ b/environment/remotes/local.go
@@ -1,0 +1,608 @@
+package remotes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"dagger.io/dagger"
+	"github.com/mitchellh/go-homedir"
+
+	"github.com/dagger/container-use/environment"
+)
+
+const (
+	containerUseRemote = "container-use"
+	gitNotesLogRef     = "container-use"
+	gitNotesStateRef   = "container-use-state"
+)
+
+const maxFileSizeForTextCheck = 10 * 1024 * 1024
+
+// LocalRemote implements the Remote interface using local filesystem and git
+type LocalRemote struct {
+	dag *dagger.Client
+}
+
+// NewLocalRemote creates a new LocalRemote instance
+func NewLocalRemote(dag *dagger.Client) *LocalRemote {
+	return &LocalRemote{dag: dag}
+}
+
+// storage represents the local storage for an environment
+type storage struct {
+	repoPath     string
+	worktreePath string
+	branch       string
+}
+
+// RemoteUrl returns the file:// URL for the project storage
+func (r *LocalRemote) RemoteUrl(project string) string {
+	repoPath, err := getRepoPath(project)
+	if err != nil {
+		return ""
+	}
+	return "file://" + repoPath
+}
+
+// Create initializes storage for a new environment
+func (r *LocalRemote) Create(env *environment.Environment) error {
+	ctx := context.Background()
+
+	localRepoPath, err := filepath.Abs(env.Source())
+	if err != nil {
+		return err
+	}
+
+	cuRepoPath, err := initializeLocalRemote(ctx, localRepoPath)
+	if err != nil {
+		return err
+	}
+
+	worktreePath, err := homedir.Expand(fmt.Sprintf("~/.config/container-use/worktrees/%s", env.ID))
+	if err != nil {
+		return err
+	}
+
+	s := &storage{
+		repoPath:     cuRepoPath,
+		worktreePath: worktreePath,
+		branch:       env.ID,
+	}
+
+	// Determine the default branch
+	defaultBranch, err := runGitCommand(ctx, localRepoPath, "branch", "--show-current")
+	if err != nil || strings.TrimSpace(defaultBranch) == "" {
+		// Try to get the default branch name
+		defaultBranch, err = runGitCommand(ctx, localRepoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
+		if err != nil {
+			defaultBranch = "main" // fallback
+		} else {
+			defaultBranch = strings.TrimPrefix(strings.TrimSpace(defaultBranch), "refs/remotes/origin/")
+		}
+	} else {
+		defaultBranch = strings.TrimSpace(defaultBranch)
+	}
+
+	if err := s.createWorktree(ctx, defaultBranch); err != nil {
+		return err
+	}
+
+	// Generate patch from uncommitted changes in the source repo
+	patch, err := env.GeneratePatch(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to generate patch: %w", err)
+	}
+
+	// Apply the patch if there are any changes
+	if patch != "" {
+		if err := r.Patch(env, patch); err != nil {
+			return fmt.Errorf("failed to apply patch: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Save saves the environment state and commits changes
+func (r *LocalRemote) Save(env *environment.Environment, commitName, commitDescription string) error {
+	ctx := context.Background()
+	s, err := r.getStorage(env)
+	if err != nil {
+		return err
+	}
+
+	if err := s.save(ctx, env); err != nil {
+		return err
+	}
+
+	if err := s.commitStateToNotes(ctx, env); err != nil {
+		return err
+	}
+
+	name := commitName
+	if name == "" {
+		name = "Auto-save"
+	}
+
+	description := commitDescription
+	if description == "" {
+		description = "Automatic save"
+	}
+
+	return s.commitChanges(ctx, name, description)
+}
+
+// Note adds a note to the environment
+func (r *LocalRemote) Note(env *environment.Environment, note string) error {
+	ctx := context.Background()
+	s, err := r.getStorage(env)
+	if err != nil {
+		return err
+	}
+
+	return s.addGitNote(ctx, note)
+}
+
+// Patch applies uncommitted changes to the environment
+func (r *LocalRemote) Patch(env *environment.Environment, patch string) error {
+	ctx := context.Background()
+	s, err := r.getStorage(env)
+	if err != nil {
+		return err
+	}
+
+	return s.applyPatch(ctx, patch)
+}
+
+// Load loads the environment state from storage
+func (r *LocalRemote) Load(env *environment.Environment) error {
+	s, err := r.getStorage(env)
+	if err != nil {
+		return err
+	}
+
+	return s.load(env)
+}
+
+// Delete removes the environment from storage
+func (r *LocalRemote) Delete(envName string) error {
+	// Implementation would remove the worktree and clean up storage
+	// For now, return nil as the original implementation doesn't have this
+	return nil
+}
+
+// BaseProjectDir returns the base project directory for building containers
+func (r *LocalRemote) BaseProjectDir(env *environment.Environment) *dagger.Directory {
+	s, err := r.getStorage(env)
+	if err != nil {
+		return nil
+	}
+
+	return r.dag.Host().Directory(s.worktreePath)
+}
+
+// getStorage creates a storage instance for the environment
+func (r *LocalRemote) getStorage(env *environment.Environment) (*storage, error) {
+	localRepoPath, err := filepath.Abs(env.Source())
+	if err != nil {
+		return nil, err
+	}
+
+	cuRepoPath, err := getRepoPath(filepath.Base(localRepoPath))
+	if err != nil {
+		return nil, err
+	}
+
+	worktreePath, err := homedir.Expand(fmt.Sprintf("~/.config/container-use/worktrees/%s", env.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	return &storage{
+		repoPath:     cuRepoPath,
+		worktreePath: worktreePath,
+		branch:       env.ID,
+	}, nil
+}
+
+// Helper functions moved from git.go
+
+func getRepoPath(repoName string) (string, error) {
+	return homedir.Expand(fmt.Sprintf("~/.config/container-use/repos/%s", filepath.Base(repoName)))
+}
+
+func initializeLocalRemote(ctx context.Context, localRepoPath string) (string, error) {
+	localRepoPath, err := filepath.Abs(localRepoPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if localRepoPath is a git repository, initialize if not
+	if _, err := os.Stat(filepath.Join(localRepoPath, ".git")); os.IsNotExist(err) {
+		slog.Info("Initializing git repository", "path", localRepoPath)
+		_, err = runGitCommand(ctx, localRepoPath, "init")
+		if err != nil {
+			return "", err
+		}
+
+		// Create an initial commit if the repo is empty
+		_, err = runGitCommand(ctx, localRepoPath, "commit", "--allow-empty", "-m", "Initial commit")
+		if err != nil {
+			return "", err
+		}
+	}
+
+	repoName := filepath.Base(localRepoPath)
+	cuRepoPath, err := getRepoPath(repoName)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := os.Stat(cuRepoPath); err != nil {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		slog.Info("Initializing storage repository", "source", localRepoPath, "storage", cuRepoPath)
+		_, err = runGitCommand(ctx, localRepoPath, "clone", "--bare", localRepoPath, cuRepoPath)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Set up remote in source repo pointing to storage
+	existingURL, err := runGitCommand(ctx, localRepoPath, "remote", "get-url", containerUseRemote)
+	if err != nil {
+		_, err = runGitCommand(ctx, localRepoPath, "remote", "add", containerUseRemote, cuRepoPath)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		existingURL = strings.TrimSpace(existingURL)
+		if existingURL != cuRepoPath {
+			_, err = runGitCommand(ctx, localRepoPath, "remote", "set-url", containerUseRemote, cuRepoPath)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+	return cuRepoPath, nil
+}
+
+func runGitCommand(ctx context.Context, dir string, args ...string) (out string, rerr error) {
+	slog.Info(fmt.Sprintf("[%s] $ git %s", dir, strings.Join(args, " ")))
+	defer func() {
+		slog.Info(fmt.Sprintf("[%s] $ git %s (DONE)", dir, strings.Join(args, " ")), "err", rerr)
+	}()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("git command failed (exit code %d): %w\nOutput: %s",
+				exitErr.ExitCode(), err, string(output))
+		}
+		return "", fmt.Errorf("git command failed: %w", err)
+	}
+
+	return string(output), nil
+}
+
+func (s *storage) createWorktree(ctx context.Context, sourceBranch string) error {
+	if _, err := os.Stat(s.worktreePath); err == nil {
+		return nil
+	}
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(s.worktreePath), 0755); err != nil {
+		return err
+	}
+
+	// Create worktree from storage repo - check if our target branch already exists
+	_, err := runGitCommand(ctx, s.repoPath, "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", s.branch))
+	if err != nil {
+		// Branch doesn't exist, create it from sourceBranch
+		_, err = runGitCommand(ctx, s.repoPath, "worktree", "add", "-b", s.branch, s.worktreePath, sourceBranch)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Branch exists, checkout to it
+		_, err = runGitCommand(ctx, s.repoPath, "worktree", "add", s.worktreePath, s.branch)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *storage) save(ctx context.Context, env *environment.Environment) error {
+	_, err := env.Container().Directory(env.Workdir).Export(
+		ctx,
+		s.worktreePath,
+		dagger.DirectoryExportOpts{Wipe: true},
+	)
+	if err != nil {
+		return err
+	}
+
+	cfg := filepath.Join(s.worktreePath, ".container-use")
+	if err := os.MkdirAll(cfg, 0755); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(cfg, "AGENT.md"), []byte(env.Instructions), 0644); err != nil {
+		return err
+	}
+
+	envState, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(cfg, "environment.json"), envState, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *storage) load(env *environment.Environment) error {
+	cfg := filepath.Join(s.worktreePath, ".container-use")
+
+	instructions, err := os.ReadFile(filepath.Join(cfg, "AGENT.md"))
+	if err != nil {
+		return err
+	}
+	env.Instructions = string(instructions)
+
+	envState, err := os.ReadFile(filepath.Join(cfg, "environment.json"))
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(envState, env); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *storage) commitChanges(ctx context.Context, name, explanation string) error {
+	status, err := runGitCommand(ctx, s.worktreePath, "status", "--porcelain")
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(status) == "" {
+		return nil
+	}
+
+	if err := addNonBinaryFiles(ctx, s.worktreePath); err != nil {
+		return err
+	}
+
+	commitMsg := fmt.Sprintf("%s\n\n%s", name, explanation)
+	_, err = runGitCommand(ctx, s.worktreePath, "commit", "-m", commitMsg)
+	return err
+}
+
+func (s *storage) commitStateToNotes(ctx context.Context, env *environment.Environment) error {
+	buff, err := json.MarshalIndent(env.History, "", "  ")
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(os.TempDir(), ".container-use-git-notes-*")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(buff); err != nil {
+		return err
+	}
+
+	_, err = runGitCommand(ctx, s.worktreePath, "notes", "--ref", gitNotesStateRef, "add", "-f", "-F", f.Name())
+	return err
+}
+
+func (s *storage) addGitNote(ctx context.Context, note string) error {
+	_, err := runGitCommand(ctx, s.worktreePath, "notes", "--ref", gitNotesLogRef, "append", "-m", note)
+	return err
+}
+
+func (s *storage) applyPatch(ctx context.Context, patchContent string) error {
+	if strings.TrimSpace(patchContent) == "" {
+		return nil
+	}
+
+	slog.Info("Applying patch to worktree")
+
+	cmd := exec.Command("git", "apply")
+	cmd.Dir = s.worktreePath
+	cmd.Stdin = strings.NewReader(patchContent)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to apply patch: %w\nOutput: %s", err, string(output))
+	}
+
+	return s.commitChanges(ctx, "Apply patch", "Applied patch with uncommitted changes")
+}
+
+func addNonBinaryFiles(ctx context.Context, worktreePath string) error {
+	statusOutput, err := runGitCommand(ctx, worktreePath, "status", "--porcelain")
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(strings.TrimSpace(statusOutput), "\n")
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		if len(line) < 3 {
+			continue
+		}
+
+		indexStatus := line[0]
+		workTreeStatus := line[1]
+		fileName := strings.TrimSpace(line[2:])
+		if fileName == "" {
+			continue
+		}
+
+		if shouldSkipFile(fileName) {
+			continue
+		}
+
+		switch {
+		case indexStatus == '?' && workTreeStatus == '?':
+			if strings.HasSuffix(fileName, "/") {
+				dirName := strings.TrimSuffix(fileName, "/")
+				if err := addFilesFromUntrackedDirectory(ctx, worktreePath, dirName); err != nil {
+					return err
+				}
+			} else {
+				if !isBinaryFile(worktreePath, fileName) {
+					_, err = runGitCommand(ctx, worktreePath, "add", fileName)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		case indexStatus == 'A':
+			continue
+		case indexStatus == 'D' || workTreeStatus == 'D':
+			_, err = runGitCommand(ctx, worktreePath, "add", fileName)
+			if err != nil {
+				return err
+			}
+		default:
+			if !isBinaryFile(worktreePath, fileName) {
+				_, err = runGitCommand(ctx, worktreePath, "add", fileName)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func shouldSkipFile(fileName string) bool {
+	skipExtensions := []string{
+		".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz",
+		".zip", ".rar", ".7z", ".gz", ".bz2", ".xz",
+		".exe", ".bin", ".dmg", ".pkg", ".msi",
+		".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".svg",
+		".mp3", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv",
+		".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+		".so", ".dylib", ".dll", ".a", ".lib",
+	}
+
+	lowerName := strings.ToLower(fileName)
+	for _, ext := range skipExtensions {
+		if strings.HasSuffix(lowerName, ext) {
+			return true
+		}
+	}
+
+	skipPatterns := []string{
+		"node_modules/", ".git/", "__pycache__/", ".DS_Store",
+		"venv/", ".venv/", "env/", ".env/",
+		"target/", "build/", "dist/", ".next/",
+		"*.tmp", "*.temp", "*.cache", "*.log",
+	}
+
+	for _, pattern := range skipPatterns {
+		if strings.Contains(lowerName, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func addFilesFromUntrackedDirectory(ctx context.Context, worktreePath, dirName string) error {
+	dirPath := filepath.Join(worktreePath, dirName)
+
+	return filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(worktreePath, path)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			if shouldSkipFile(relPath + "/") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if shouldSkipFile(relPath) {
+			return nil
+		}
+
+		if !isBinaryFile(worktreePath, relPath) {
+			_, err = runGitCommand(ctx, worktreePath, "add", relPath)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func isBinaryFile(worktreePath, fileName string) bool {
+	fullPath := filepath.Join(worktreePath, fileName)
+
+	stat, err := os.Stat(fullPath)
+	if err != nil {
+		return true
+	}
+
+	if stat.IsDir() {
+		return false
+	}
+
+	if stat.Size() > maxFileSizeForTextCheck {
+		return true
+	}
+
+	file, err := os.Open(fullPath)
+	if err != nil {
+		slog.Error("Error opening file", "err", err)
+		return true
+	}
+	defer file.Close()
+
+	buffer := make([]byte, 8000)
+	n, err := file.Read(buffer)
+	if err != nil && n == 0 {
+		return true
+	}
+
+	buffer = buffer[:n]
+	if slices.Contains(buffer, 0) {
+		return true
+	}
+
+	return false
+}

--- a/environment/remotes/local.go
+++ b/environment/remotes/local.go
@@ -43,12 +43,22 @@ type storage struct {
 	branch       string
 }
 
-// RemoteUrl returns the file:// URL for the project storage
+// RemoteUrl returns the file:// URL for the project storage, ensuring the remote exists
 func (r *LocalRemote) RemoteUrl(project string) string {
-	repoPath, err := getRepoPath(project)
+	ctx := context.Background()
+
+	// Get absolute path of the project
+	projectPath, err := filepath.Abs(project)
 	if err != nil {
 		return ""
 	}
+
+	// Initialize the remote storage if it doesn't exist
+	repoPath, err := initializeLocalRemote(ctx, projectPath)
+	if err != nil {
+		return ""
+	}
+
 	return "file://" + repoPath
 }
 

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -120,32 +120,26 @@ func init() {
 }
 
 type EnvironmentResponse struct {
-	ID               string   `json:"id"`
-	BaseImage        string   `json:"base_image"`
-	SetupCommands    []string `json:"setup_commands"`
-	Instructions     string   `json:"instructions"`
-	Workdir          string   `json:"workdir"`
-	Branch           string   `json:"branch"`
-	TrackingBranch   string   `json:"tracking_branch"`
-	CheckoutCommand  string   `json:"checkout_command_for_human"`
-	HostWorktreePath string   `json:"host_worktree_path"`
+	ID              string   `json:"id"`
+	BaseImage       string   `json:"base_image"`
+	SetupCommands   []string `json:"setup_commands"`
+	Instructions    string   `json:"instructions"`
+	Workdir         string   `json:"workdir"`
+	Branch          string   `json:"branch"`
+	TrackingBranch  string   `json:"tracking_branch"`
+	CheckoutCommand string   `json:"checkout_command_for_human"`
 }
 
 func EnvironmentToCallResult(env *environment.Environment) (*mcp.CallToolResult, error) {
-	worktreePath, err := env.GetWorktreePath()
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to get worktree", err), nil
-	}
 	resp := &EnvironmentResponse{
-		ID:               env.ID,
-		Instructions:     env.Instructions,
-		BaseImage:        env.BaseImage,
-		SetupCommands:    env.SetupCommands,
-		Workdir:          env.Workdir,
-		Branch:           env.ID,
-		TrackingBranch:   fmt.Sprintf("container-use/%s", env.ID),
-		CheckoutCommand:  fmt.Sprintf("git checkout %s", env.ID),
-		HostWorktreePath: worktreePath,
+		ID:              env.ID,
+		Instructions:    env.Instructions,
+		BaseImage:       env.BaseImage,
+		SetupCommands:   env.SetupCommands,
+		Workdir:         env.Workdir,
+		Branch:          env.ID,
+		TrackingBranch:  fmt.Sprintf("container-use/%s", env.ID),
+		CheckoutCommand: fmt.Sprintf("git checkout %s", env.ID),
 	}
 	out, err := json.Marshal(resp)
 	if err != nil {


### PR DESCRIPTION
this is deeply not done yet, but the intent of this PR is to rework the git code to properly separate storage concerns from userland repository manipulations. 

it should maintain feature parity for the most part, but i did rip out support for copying untracked files into the remote container because it's hard to do without heavily violating my new abstraction boundary.

TODOs:
- audit the rest of the interface to try to take parts of envs instead of whole ones. idk if that's possible right now, especially because Remote.Load(*env) is copying into that pointer, but gonna investigate anyways... the end goal is to delete the interface altogether and have proper SoC.
- ??? i'm sure there's more, gotta keep looking for abstraction violations and testing. 

cc @grouville, depending on how you're adding units this might throw a fat wrench into things, but ultimately this refactor does have an inversion-of-control element that will make things way easier to unit test -- for env we can mock storage and do it in ram, and for LocalStorage we can construct Environments at arbitrary points for test cases.