### PR TITLE
add cu version command

### DIFF
--- a/cmd/cu/version.go
+++ b/cmd/cu/version.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  `Print the version, commit hash, and build date of the cu binary.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("cu version %s\n", version)
+		fmt.Printf("commit: %s\n", commit)
+		fmt.Printf("built: %s\n", date)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/cu/version.go
+++ b/cmd/cu/version.go
@@ -30,9 +30,13 @@ var versionCmd = &cobra.Command{
 			}
 		}
 
-		fmt.Printf("%s\n\n", currentVersion)
-		fmt.Printf("commit: %s\n", currentCommit)
-		fmt.Printf("built: %s\n", currentDate)
+		fmt.Printf("cu version %s\n", currentVersion)
+		if currentCommit != "unknown" {
+			fmt.Printf("commit: %s\n", currentCommit)
+		}
+		if currentDate != "unknown" {
+			fmt.Printf("built: %s\n", currentDate)
+		}
 	},
 }
 


### PR DESCRIPTION
useless for `go run` builds, but GoReleaser sets 

```
ldflags:
  - -s -w
  - -X main.version={{.Version}}
  - -X main.commit={{.Commit}}
  - -X main.date={{.Date}}
```

that will help us help folks debug.

I also added debug.ReadBuildInfo logic for `go build` based dev builds.