### PR TITLE
Release to homebrew

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -40,9 +40,12 @@ func (m *ContainerUse) Release(ctx context.Context,
 	version string,
 	// GitHub token for authentication
 	githubToken *dagger.Secret,
+	// GitHub org name for package publishing
+	githubOrgName string,
 ) (string, error) {
 	return dag.Goreleaser(m.Source).
 		WithSecretVariable("GITHUB_TOKEN", githubToken).
+		WithEnvVariable("GH_ORG_NAME", githubOrgName).
 		Release().
 		Run(ctx)
 }

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -40,7 +40,8 @@ func (m *ContainerUse) Release(ctx context.Context,
 	version string,
 	// GitHub token for authentication
 	githubToken *dagger.Secret,
-	// GitHub org name for package publishing
+	// GitHub org name for package publishing, set only if testing release process on a personal fork
+	//+default="dagger"
 	githubOrgName string,
 ) (string, error) {
 	return dag.Goreleaser(m.Source).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           version: "latest"
           verb: call
-          args: release --version "${GITHUB_REF#refs/tags/}" --github-token env:GITHUB_TOKEN
+          args: release --version "${GITHUB_REF#refs/tags/}" --github-token env:RELEASE_GITHUB_TOKEN
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,7 @@ archives:
 
 homebrew_casks:
   - repository:
-      owner: dagger # reconfigure if test releasing on your own fork
+      owner: "{{ .Env.GH_ORG_NAME }}" # reconfigure if test releasing on your own fork
       name: homebrew-tap
       pull_request:
         enabled: true # enabled so we can publish draft releases, publish them, then merge the tap PR. to be removed later.
@@ -48,8 +48,8 @@ homebrew_casks:
       name: container-use-bot
       email: noreply@dagger.io
     url:
-      template: "https://github.com/dagger/container-use/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    homepage: "https://github.com/dagger/container-use"
+      template: "https://github.com/{{ .Env.GH_ORG_NAME }}/container-use/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/{{ .Env.GH_ORG_NAME }}/container-use"
     description: "Containerized environments for coding agents"
     hooks:
       post:
@@ -75,7 +75,7 @@ changelog:
 
 release:
   github:
-    owner: dagger # reconfigure if test releasing on your own fork
+    owner: "{{ .Env.GH_ORG_NAME }}" # reconfigure if test releasing on your own fork
     name: container-use
   draft: true
   prerelease: auto
@@ -85,4 +85,4 @@ release:
 
     Download the pre-compiled binaries from the assets below.
   footer: |
-    **Full Changelog**: https://github.com/dagger/container-use/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/{{ .Env.GH_ORG_NAME }}/container-use/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,16 +37,19 @@ archives:
 
 homebrew_casks:
   - repository:
-      owner: "{{ .Env.GH_ORG_NAME }}"
+      owner: dagger # reconfigure if test releasing on your own fork
       name: homebrew-tap
+      pull_request:
+        enabled: true # enabled so we can publish draft releases, publish them, then merge the tap PR. to be removed later.
     name: container-use
     binary: cu
+    skip_upload: auto # if the version is like v0.0.0-rc1, don't make the tap PR.
     commit_author:
-      name: dagger-bot
+      name: container-use-bot
       email: noreply@dagger.io
     url:
-      template: "https://github.com/cwlbraa/container-use/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    homepage: "https://github.com/cwlbraa/container-use"
+      template: "https://github.com/dagger/container-use/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/dagger/container-use"
     description: "Containerized environments for coding agents"
     hooks:
       post:
@@ -72,7 +75,7 @@ changelog:
 
 release:
   github:
-    owner: cwlbraa
+    owner: dagger # reconfigure if test releasing on your own fork
     name: container-use
   draft: true
   prerelease: auto
@@ -82,4 +85,4 @@ release:
 
     Download the pre-compiled binaries from the assets below.
   footer: |
-    **Full Changelog**: https://github.com/cwlbraa/container-use/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/dagger/container-use/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,26 @@ archives:
       - README.md
       - LICENSE
 
+homebrew_casks:
+  - repository:
+      owner: "{{ .Env.GH_ORG_NAME }}"
+      name: homebrew-tap
+    name: container-use
+    binary: cu
+    commit_author:
+      name: dagger-bot
+      email: noreply@dagger.io
+    url:
+      template: "https://github.com/cwlbraa/container-use/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/cwlbraa/container-use"
+    description: "Containerized environments for coding agents"
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cu"]
+          end
+
 checksum:
   name_template: "checksums.txt"
 
@@ -51,12 +71,15 @@ changelog:
       - "Merge branch"
 
 release:
+  github:
+    owner: cwlbraa
+    name: container-use
   draft: true
   prerelease: auto
   mode: replace
   header: |
     ## container-use {{ .Tag }}
-    
+
     Download the pre-compiled binaries from the assets below.
   footer: |
-    **Full Changelog**: https://github.com/dagger/container-use/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/cwlbraa/container-use/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ It's an open-source MCP server that works as a CLI tool with Claude Code, Cursor
 
 ## Install
 
+### macOS (Homebrew - Recommended)
+
+```sh
+brew install dagger/tap/container-use
+```
+
+### All Platforms (Shell Script)
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/dagger/container-use/main/install.sh | bash
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,4 +28,8 @@
    - Edit the draft release if needed
    - Click "Publish release"
 
+6. **Merge the homebrew tap PR**
+   - After publishing the release, a PR will be automatically created in [dagger/homebrew-tap](https://github.com/dagger/homebrew-tap)
+   - Review and merge the PR to make the release available via Homebrew
+
 The Dagger CI automatically handles building binaries and creating the draft release when tags are pushed.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,9 +4,10 @@
 
 1. **Fetch the latest main branch**
    ```sh
-   git checkout main
-   git pull origin main
+   git fetch origin main
+   git checkout origin/main
    ```
+   NOTE: this puts you on a detached head, which is fine for tagging and pushing the tag.
 
 2. **Tag the release**
    ```sh


### PR DESCRIPTION
**NOTE**: this requires that we configure a token that has Content and PR R/W permissions on container-use and homebrew-tap repos. I do not have the powers, but there's a pending one called `release-container-use` that has the right stuff. I also don't think I have the right permissions to configure that on GHA unless they moved the button on me.

I've tested this works by forking dagger's org level homebrew tap. 

`brew install cwlbraa/homebrew-tap/container-use` should work for you, too. It overrides MacOS's quarantine thing.

TODO:
- [x] set up credential in container-use GHA