### PR TITLE
rules: removes glob to cursor rules

### DIFF
--- a/rules/cursor.mdc
+++ b/rules/cursor.mdc
@@ -1,6 +1,6 @@
 ---
 description: "Container-use rules for safe containerized development"
-globs: ["**/*"]
+globs:
 alwaysApply: true
 ---
 


### PR DESCRIPTION
Made some experiments with cursor, the globing seems to cause issues with some files. Was able to get the rule applied every time after removing the glob argument (empty glob seems to be the norm for applying to all files).