### PR TITLE
ci: fix brew tap PR goreleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,13 +39,10 @@ homebrew_casks:
   - repository:
       owner: "{{ .Env.GH_ORG_NAME }}"
       name: homebrew-tap
+      branch: "{{ .ProjectName }}-{{ .Version }}"
       token: "{{ .Env.GITHUB_TOKEN }}"
       pull_request:
         enabled: true
-        base:
-          owner: "{{ .Env.GH_ORG_NAME }}"
-          name: homebrew-tap
-          branch: main
     name: container-use
     binary: cu
     skip_upload: auto # if the version is like v0.0.0-rc1, don't make the tap PR.


### PR DESCRIPTION
this is my last push and pray attempt. upon closer inspection of the goreleaser docs instead of just the yaml schema, the issue here was that we were opening a PR from main onto main. 

https://goreleaser.com/customization/homebrew_casks/
```yaml
   # Make sure the 'branch' property is different from base before enabling
   # it.
   pr:
```
if this doesn't work I'll set up my fork-oriented testing again, it's just a bit of a hassle.