### PR TITLE
cli: sanity checks and cleanup

### DIFF
--- a/cmd/cu/delete.go
+++ b/cmd/cu/delete.go
@@ -2,39 +2,30 @@ package main
 
 import (
 	"fmt"
-	"io"
 
-	"dagger.io/dagger"
-	"github.com/dagger/container-use/environment"
 	"github.com/dagger/container-use/repository"
 	"github.com/spf13/cobra"
 )
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete <env>",
-	Short: "Delete an environment",
-	Long:  `Delete an environment and its associated resources.`,
-	Args:  cobra.ExactArgs(1),
+	Use:   "delete <env>...",
+	Short: "Delete environments",
+	Long:  `Delete one or more environments and their associated resources.`,
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
-		envID := args[0]
 
-		dag, err := dagger.Connect(ctx, dagger.WithLogOutput(io.Discard))
-		if err != nil {
-			return fmt.Errorf("failed to connect to dagger: %w", err)
-		}
-		defer dag.Close()
-		environment.Initialize(dag)
+		for _, envID := range args {
+			repo, err := repository.Open(ctx, ".")
+			if err != nil {
+				return fmt.Errorf("failed to open repository: %w", err)
+			}
+			if err := repo.Delete(ctx, envID); err != nil {
+				return fmt.Errorf("failed to delete environment: %w", err)
+			}
 
-		repo, err := repository.Open(ctx, ".")
-		if err != nil {
-			return fmt.Errorf("failed to open repository: %w", err)
+			fmt.Printf("Environment '%s' deleted successfully.\n", envID)
 		}
-		if err := repo.Delete(ctx, envID); err != nil {
-			return fmt.Errorf("failed to delete environment: %w", err)
-		}
-
-		fmt.Printf("Environment '%s' deleted successfully.\n", envID)
 		return nil
 	},
 }

--- a/cmd/cu/log.go
+++ b/cmd/cu/log.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/dagger/container-use/repository"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,13 @@ var logCmd = &cobra.Command{
 	Short: "Show the log for an environment",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(app *cobra.Command, args []string) error {
+		ctx := app.Context()
+
+		// Ensure we're in a git repository
+		if _, err := repository.Open(ctx, "."); err != nil {
+			return err
+		}
+
 		env := args[0]
 		// prevent accidental single quotes to mess up command
 		env = strings.Trim(env, "'")

--- a/cmd/cu/merge.go
+++ b/cmd/cu/merge.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/dagger/container-use/repository"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +13,14 @@ var mergeCmd = &cobra.Command{
 	Short: "Merges an environment into the current git branch",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(app *cobra.Command, args []string) error {
-		env := args[0]
 		ctx := app.Context()
+
+		// Ensure we're in a git repository
+		if _, err := repository.Open(ctx, "."); err != nil {
+			return err
+		}
+
+		env := args[0]
 		err := exec.Command("git", "stash", "--include-untracked", "-q").Run()
 		if err == nil {
 			defer exec.Command("git", "stash", "pop", "-q").Run()

--- a/cmd/cu/watch.go
+++ b/cmd/cu/watch.go
@@ -3,6 +3,7 @@ package main
 import (
 	"time"
 
+	"github.com/dagger/container-use/repository"
 	"github.com/spf13/cobra"
 	watch "github.com/tiborvass/go-watch"
 )
@@ -12,6 +13,13 @@ var watchCmd = &cobra.Command{
 	Short: "Watch git log output",
 	Long:  `Watch the following git log command every second: 'git log --color=always --remotes=container-use --oneline --graph --decorate'.`,
 	RunE: func(app *cobra.Command, _ []string) error {
+		ctx := app.Context()
+
+		// Ensure we're in a git repository
+		if _, err := repository.Open(ctx, "."); err != nil {
+			return err
+		}
+
 		w := watch.Watcher{Interval: time.Second}
 		w.Watch(app.Context(), "git", "log", "--color=always", "--remotes=container-use", "--oneline", "--graph", "--decorate")
 		return nil

--- a/repository/git.go
+++ b/repository/git.go
@@ -72,9 +72,8 @@ func (r *Repository) deleteWorktree(id string) error {
 	if err != nil {
 		return err
 	}
-	parentDir := filepath.Dir(worktreePath)
-	fmt.Printf("Deleting parent directory of worktree at %s\n", parentDir)
-	return os.RemoveAll(parentDir)
+	fmt.Printf("Deleting worktree at %s\n", worktreePath)
+	return os.RemoveAll(worktreePath)
 }
 
 func (r *Repository) deleteLocalRemoteBranch(id string) error {


### PR DESCRIPTION
- Use the "git root" as the base directory
- Add sanity checks to ensure we're running from a git repo, clear error
  message if not.
- Make sure all commands go through `repository.Open()` to ensure sanity
  checks are being run.

