### PR TITLE
cu checkout

### DIFF
--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dagger/container-use/repository"
+	"github.com/spf13/cobra"
+)
+
+var checkoutCmd = &cobra.Command{
+	Use:   "checkout <env>",
+	Short: "Check out an environment in git",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(app *cobra.Command, args []string) error {
+		ctx := app.Context()
+		envID := args[0]
+
+		// Ensure we're in a git repository
+		repo, err := repository.Open(ctx, ".")
+		if err != nil {
+			return err
+		}
+
+		branch, err := repo.Checkout(ctx, envID)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Switched to branch '%s'\n", branch)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(checkoutCmd)
+}

--- a/repository/git.go
+++ b/repository/git.go
@@ -149,15 +149,6 @@ func (r *Repository) initializeWorktree(ctx context.Context, id string) (string,
 		return "", err
 	}
 
-	// set up remote tracking branch if it's not already there
-	_, err = runGitCommand(ctx, r.userRepoPath, "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", id))
-	if err != nil {
-		_, err = runGitCommand(ctx, r.userRepoPath, "branch", "--track", id, fmt.Sprintf("%s/%s", containerUseRemote, id))
-		if err != nil {
-			return "", err
-		}
-	}
-
 	return worktreePath, nil
 }
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -206,3 +206,24 @@ func (r *Repository) Delete(ctx context.Context, id string) error {
 	}
 	return nil
 }
+
+func (r *Repository) Checkout(ctx context.Context, id string) (string, error) {
+	if err := r.exists(ctx, id); err != nil {
+		return "", err
+	}
+
+	branch := "cu-" + id
+
+	// set up remote tracking branch if it's not already there
+	_, err := runGitCommand(ctx, r.userRepoPath, "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", branch))
+	if err != nil {
+		_, err = runGitCommand(ctx, r.userRepoPath, "branch", "--track", branch, fmt.Sprintf("%s/%s", containerUseRemote, id))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	_, err = runGitCommand(ctx, r.userRepoPath, "checkout", branch)
+
+	return branch, err
+}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -216,14 +216,42 @@ func (r *Repository) Checkout(ctx context.Context, id string) (string, error) {
 
 	// set up remote tracking branch if it's not already there
 	_, err := runGitCommand(ctx, r.userRepoPath, "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", branch))
-	if err != nil {
+	localBranchExists := err == nil
+	if !localBranchExists {
 		_, err = runGitCommand(ctx, r.userRepoPath, "branch", "--track", branch, fmt.Sprintf("%s/%s", containerUseRemote, id))
 		if err != nil {
 			return "", err
 		}
 	}
 
-	_, err = runGitCommand(ctx, r.userRepoPath, "checkout", branch)
+	_, err = runGitCommand(ctx, r.userRepoPath, "checkout", id)
+	if err != nil {
+		return "", err
+	}
+
+	if localBranchExists {
+		remoteRef := fmt.Sprintf("%s/%s", containerUseRemote, id)
+
+		counts, err := runGitCommand(ctx, r.userRepoPath, "rev-list", "--left-right", "--count", fmt.Sprintf("HEAD...%s", remoteRef))
+		if err != nil {
+			return branch, err
+		}
+
+		parts := strings.Split(strings.TrimSpace(counts), "\t")
+		if len(parts) != 2 {
+			return branch, fmt.Errorf("unexpected git rev-list output: %s", counts)
+		}
+		aheadCount, behindCount := parts[0], parts[1]
+
+		if behindCount != "0" && aheadCount == "0" {
+			_, err = runGitCommand(ctx, r.userRepoPath, "merge", "--ff-only", remoteRef)
+			if err != nil {
+				return branch, err
+			}
+		} else if behindCount != "0" {
+			return branch, fmt.Errorf("switched to %s, but %s is %s ahead and container-use/ remote has %s additional commits", branch, branch, aheadCount, behindCount)
+		}
+	}
 
 	return branch, err
 }

--- a/rules/agent.md
+++ b/rules/agent.md
@@ -2,4 +2,4 @@ ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—N
 
 DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
 
-You MUST inform the user how to view your work using `git checkout <branch_name>`. Failure to do this will make your work inaccessible to others.
+You MUST inform the user how to view your work using `cu log <env_id>` AND `cu checkout <env_id>`. Failure to do this will make your work inaccessible to others.

--- a/rules/cursor.mdc
+++ b/rules/cursor.mdc
@@ -6,11 +6,6 @@ alwaysApply: true
 
 ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.
 
-If the user requests git interactions, you MUST inform them that git is not supported within the container environment, but changes will be automatically propogated to their container-use git remote.
-You must NEVER install the git CLI.
-Running "rm .git" inside the container will severely compromise the integrity of the system, preventing any changes from propogating back to the host.
-Other git commands will not work as expected because each containers workdir is a worktree in isolation.
+DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
 
-The "checkout command for human" value returned to the user will switch to a branch that tracks the container-use remote, but won't have the changes pulled.
-
-You MUST inform the user how to view their changes using a "git checkout" command that does not include container-use/remote. Your work will be useless without reporting this!
+You MUST inform the user how to view your work using `cu log <env_id>` and `cu checkout <env_id>`. Failure to do this will make your work inaccessible to others.


### PR DESCRIPTION
- Do not set up remote tracking branches for each environment anymore
- Instead, provide an explicit `cu checkout` command that does that
- Similar to `gh pr checkout`

This still requires reworking the prompt engineering behind the scenes

DEPENDS ON #107

