### PR TITLE
remove environment names

### DIFF
--- a/cmd/cu/list.go
+++ b/cmd/cu/list.go
@@ -26,7 +26,7 @@ var listCmd = &cobra.Command{
 		}
 		if quiet, _ := app.Flags().GetBool("quiet"); quiet {
 			for _, env := range envs {
-				fmt.Println(env.Name)
+				fmt.Println(env.ID)
 			}
 			return nil
 		}
@@ -36,7 +36,7 @@ var listCmd = &cobra.Command{
 
 		defer tw.Flush()
 		for _, env := range envs {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", env.Name, truncate(app, env.State.Title, 40), humanize.Time(env.State.CreatedAt), humanize.Time(env.State.UpdatedAt))
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", env.ID, truncate(app, env.State.Title, 40), humanize.Time(env.State.CreatedAt), humanize.Time(env.State.UpdatedAt))
 		}
 		return nil
 	},

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -26,7 +26,6 @@ type Environment struct {
 	State  *State
 
 	ID       string
-	Name     string
 	Worktree string
 
 	Services []*Service
@@ -35,10 +34,9 @@ type Environment struct {
 	mu sync.RWMutex
 }
 
-func New(ctx context.Context, id, name, title, worktree string) (*Environment, error) {
+func New(ctx context.Context, id, title, worktree string) (*Environment, error) {
 	env := &Environment{
 		ID:       id,
-		Name:     name,
 		Worktree: worktree,
 		Config:   DefaultConfig(),
 		State: &State{
@@ -59,7 +57,7 @@ func New(ctx context.Context, id, name, title, worktree string) (*Environment, e
 		return nil, err
 	}
 
-	slog.Info("Creating environment", "id", env.ID, "name", env.Name, "workdir", env.Config.Workdir)
+	slog.Info("Creating environment", "id", env.ID, "workdir", env.Config.Workdir)
 
 	if err := env.apply(ctx, "Create environment", "Create the environment", "", container); err != nil {
 		return nil, err
@@ -93,10 +91,9 @@ func (env *Environment) container() *dagger.Container {
 	return dag.LoadContainerFromID(dagger.ContainerID(env.State.Container))
 }
 
-func Load(ctx context.Context, id, name string, state []byte, worktree string) (*Environment, error) {
+func Load(ctx context.Context, id string, state []byte, worktree string) (*Environment, error) {
 	env := &Environment{
 		ID:       id,
-		Name:     id,
 		Worktree: worktree,
 		Config:   DefaultConfig(),
 		State:    &State{},

--- a/repository/git.go
+++ b/repository/git.go
@@ -164,13 +164,11 @@ func (r *Repository) initializeWorktree(ctx context.Context, id string) (string,
 func (r *Repository) propagateToWorktree(ctx context.Context, env *environment.Environment, name, explanation string) (rerr error) {
 	slog.Info("Propagating to worktree...",
 		"environment.id", env.ID,
-		"environment.name", env.Name,
 		"workdir", env.Config.Workdir,
 		"id", env.ID)
 	defer func() {
 		slog.Info("Propagating to worktree... (DONE)",
 			"environment.id", env.ID,
-			"environment.name", env.Name,
 			"workdir", env.Config.Workdir,
 			"id", env.ID,
 			"err", rerr)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -120,7 +120,6 @@ func (r *Repository) Get(ctx context.Context, id string) (*environment.Environme
 		return nil, err
 	}
 
-	name, _, _ := strings.Cut(id, "/")
 	worktree, err := r.initializeWorktree(ctx, id)
 	if err != nil {
 		return nil, err
@@ -131,7 +130,7 @@ func (r *Repository) Get(ctx context.Context, id string) (*environment.Environme
 		return nil, err
 	}
 
-	env, err := environment.Load(ctx, id, name, state, worktree)
+	env, err := environment.Load(ctx, id, state, worktree)
 	if err != nil {
 		return nil, err
 	}
@@ -139,19 +138,19 @@ func (r *Repository) Get(ctx context.Context, id string) (*environment.Environme
 	return env, nil
 }
 
-func (r *Repository) Create(ctx context.Context, name, description, explanation string) (*environment.Environment, error) {
-	id := fmt.Sprintf("%s/%s", name, petname.Generate(2, "-"))
+func (r *Repository) Create(ctx context.Context, description, explanation string) (*environment.Environment, error) {
+	id := petname.Generate(2, "-")
 	worktree, err := r.initializeWorktree(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	env, err := environment.New(ctx, id, name, description, worktree)
+	env, err := environment.New(ctx, id, description, worktree)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := r.propagateToWorktree(ctx, env, "Create env "+name, explanation); err != nil {
+	if err := r.propagateToWorktree(ctx, env, "Create env "+id, explanation); err != nil {
 		return nil, err
 	}
 
@@ -177,8 +176,15 @@ func (r *Repository) List(ctx context.Context) ([]*environment.Environment, erro
 	envs := []*environment.Environment{}
 	for _, branch := range strings.Split(branches, "\n") {
 		branch = strings.TrimSpace(branch)
-		// FIXME(aluzzardi): This logic is broken
-		if !strings.Contains(branch, "/") {
+
+		// FIXME(aluzzardi): This is a hack to make sure the branch is actually an environment.
+		// There must be a better way to do this.
+		worktree, err := worktreePath(branch)
+		if err != nil {
+			return nil, err
+		}
+		state, err := r.loadState(ctx, worktree)
+		if err != nil || state == nil {
 			continue
 		}
 


### PR DESCRIPTION
The environment name was used to easily recognize environments. Since
now they have a full blown description, it's not needed anymore.

DEPENDS ON #107
