### PR TITLE
Fix: Prevent git notes command hanging when no environment notes exist

### DIFF
--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -37,6 +37,8 @@ func (s *Environment) FileWrite(ctx context.Context, explanation, targetFile, co
 		return fmt.Errorf("failed applying file write, skipping git propogation: %w", err)
 	}
 
+	s.Notes.Add("Write file %s\n%s\n\n", targetFile, explanation)
+
 	return nil
 }
 
@@ -45,6 +47,8 @@ func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile st
 	if err != nil {
 		return err
 	}
+
+	s.Notes.Add("Delete file %s\n%s\n\n", targetFile, explanation)
 
 	return nil
 }

--- a/environment/service.go
+++ b/environment/service.go
@@ -122,5 +122,7 @@ func (env *Environment) AddService(ctx context.Context, explanation string, cfg 
 		return nil, err
 	}
 
+	env.Notes.Add("Add service %s\n%s\n\n", cfg.Name, explanation)
+
 	return svc, nil
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -145,8 +145,11 @@ func (r *Repository) Create(ctx context.Context, name, explanation string) (*env
 }
 
 func (r *Repository) Update(ctx context.Context, env *environment.Environment, operation, explanation string) error {
-	if err := r.addGitNote(ctx, env, env.Notes.Pop()); err != nil {
-		return err
+	note := env.Notes.Pop()
+	if strings.TrimSpace(note) != "" {
+		if err := r.addGitNote(ctx, env, note); err != nil {
+			return err
+		}
 	}
 	return r.propagateToWorktree(ctx, env, operation, explanation)
 }


### PR DESCRIPTION
## Problem

The [`Repository.Update()`](https://github.com/dagger/container-use/blob/main/repository/repository.go#L147) method was causing the application to hang when called from tool handlers that don't add notes to the environment. This happened because:

1. [`repo.Update()`](https://github.com/dagger/container-use/blob/main/repository/repository.go#L147) calls [`env.Notes.Pop()`](https://github.com/dagger/container-use/blob/main/environment/note.go#35) to get a note message.
2. When no notes were added, `Pop()` returns an empty string.
3. ⚠️ the `git notes --ref container-use append -m ""` command behaves differently depending on Git version ([reference](https://stackoverflow.com/a/76633969)):

   * On **Git versions (>= 2.42, < [2.47 batch 3](https://github.com/git/git/commit/25673b1c476756ec0587fb0596ab3c22b96dc52a), e.g. older Git on `WSL2` Windows)**, this opens the editor (like `vi`) for user input.
   
     * ![Screenshot 2025-06-20 115829](https://github.com/user-attachments/assets/76d1d553-078c-4ad1-b6b8-5c5d51419ac0)

   * On **newer Git versions (>= [2.47 batch 3](https://github.com/git/git/commit/25673b1c476756ec0587fb0596ab3c22b96dc52a) e.g., latest `macOS`)**, this is interpreted as a request to remove the note, which is a silent no-op if no note exists.
     * ![image](https://github.com/user-attachments/assets/58508662-b624-44dd-ac76-b17d94c9eb78)

This inconsistency led to hanging behavior on environments like `WSL2` where the editor gets invoked unexpectedly.

## Root Cause Analysis

Found 5 locations where [`repo.Update()`](https://github.com/dagger/container-use/blob/main/repository/repository.go#L147) is called:

### ✅ Safe Operations (already add notes):

* **EnvironmentUpdateTool** – Environment updates add notes during setup commands.
* **EnvironmentRunCmdTool** – [`env.Run()`](https://github.com/dagger/container-use/blob/main/environment/environment.go#L241) and [`env.RunBackground()`](https://github.com/dagger/container-use/blob/main/environment/environment.go#L279) both call [`env.Notes.Add()`](https://github.com/dagger/container-use/blob/main/environment/note.go#14).

### ❌ Vulnerable Operations (missing notes):

* **EnvironmentFileWriteTool** – [`env.FileWrite()`](https://github.com/dagger/container-use/blob/main/environment/filesystem.go#L34) doesn't add notes.
* **EnvironmentFileDeleteTool** – [`env.FileDelete()`](https://github.com/dagger/container-use/blob/main/environment/filesystem.go#L43) doesn't add notes.
* **EnvironmentAddServiceTool** – [`env.AddService()`](https://github.com/dagger/container-use/blob/main/environment/service.go#L108) doesn't add notes.

## Solution

### 1. Make [`Repository.Update()`](https://github.com/dagger/container-use/blob/main/repository/repository.go#L147) robust to empty notes

* Check if note is non-empty before calling [`addGitNote()`](https://github.com/dagger/container-use/blob/main/repository/git.go#L254).
* Prevents hanging or inconsistent behavior when no notes are present.

### 2. Add missing notes to vulnerable operations

* Add [`env.Notes.Add()`](https://github.com/dagger/container-use/blob/main/environment/note.go#14) calls to file operations and service management.
* Maintains consistency and provides better audit trails.
* Follows the same pattern as existing safe operations.

## Changes Made

### [`repository/repository.go`](https://github.com/dagger/container-use/blob/main/repository/repository.go)

* Modified [`Update()`](https://github.com/dagger/container-use/blob/main/repository/repository.go#L147) method to check for empty notes before calling [`addGitNote()`](https://github.com/dagger/container-use/blob/main/repository/git.go#L254).

### [`environment/filesystem.go`](https://github.com/dagger/container-use/blob/main/environment/filesystem.go)

* Added [`Notes.Add()`](https://github.com/dagger/container-use/blob/main/environment/note.go#14) calls to [`FileWrite()`](https://github.com/dagger/container-use/blob/main/environment/filesystem.go#L34) and [`FileDelete()`](https://github.com/dagger/container-use/blob/main/environment/filesystem.go#L43) methods.

### [`environment/service.go`](https://github.com/dagger/container-use/blob/main/environment/service.go)

* Added [`Notes.Add()`](https://github.com/dagger/container-use/blob/main/environment/note.go#14) call to [`AddService()`](https://github.com/dagger/container-use/blob/main/environment/service.go#L109) method.

## Reproducing Instructions (for future readers)

To demonstrate the environment-dependent behavior of `git notes --ref container-use append -m ""`:

1. On **WSL2/Windows Git 2.43.0** (or similar):

   ```bash
   # first make sure there is no note
   git notes --ref container-use show
   # Output: error: no note found for object ...

   git notes --ref container-use append -m ""
   # Opens editor (e.g., vi) waiting for user input
   ```

2. On **macOS Git 2.50.0** (or later):

   ```bash
   # first make sure there is no note
   git notes --ref container-use show
   # Output: error: no note found for object ...

   git notes --ref container-use append -m ""
   # Outputs: "Removing note for object ..." and exits without opening editor
   ```

Thus, behavior varies by Git version and platform, affecting script stability.

## Environment Details

* **WSL2/Windows Git Version**: 2.43.0
* **macOS Git Version**: 2.50.0
* **Git behavior differs in handling of `git notes append -m ""` as described above.**

## Testing

The fix addresses the hanging issue by:

1. **Immediate reliability**: Prevents `git notes` from hanging regardless of Git version.
2. **Consistency**: All operations that call `repo.Update()` now properly add notes.
3. **Audit trail**: Better tracking of file operations and service management.

## Impact

* **Bug Fix**: Resolves hanging issue in file operations and service management.
* **No Breaking Changes**: Maintains existing API and behavior.
* **Improved Observability**: Better notes tracking across all operations.