### PR TITLE
Implement semantic commit messages for environment merges

### DIFF
--- a/cmd/cu/merge.go
+++ b/cmd/cu/merge.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -18,7 +19,7 @@ var mergeCmd = &cobra.Command{
 		if err == nil {
 			defer exec.Command("git", "stash", "pop", "-q").Run()
 		}
-		cmd := exec.CommandContext(ctx, "git", "merge", "-m", "Merge environment "+env, "--", "container-use/"+env)
+		cmd := exec.CommandContext(ctx, "git", "merge", "-m", fmt.Sprintf("chore(merge): merge environment %s", env), "--", "container-use/"+env)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		return cmd.Run()


### PR DESCRIPTION
This PR updates the merge command to follow semantic commit conventions, improving git history consistency and enabling better automated tooling.

## Changes
- **Added `fmt` package import** to support string formatting
- **Updated merge commit message** from `"Merge environment <env>"` to `fmt.Sprintf("chore(merge): merge environment %s", env)`
- **Maintained all existing functionality** - stash handling, stdout/stderr wiring, and error handling remain unchanged

## Before
```go
cmd := exec.CommandContext(ctx, "git", "merge", "-m", "Merge environment "+env, "--", "container-use/"+env)
```

## After
```go
cmd := exec.CommandContext(ctx, "git", "merge", "-m", fmt.Sprintf("chore(merge): merge environment %s", env), "--", "container-use/"+env)
```

## Benefits
- **Consistent git history** - All merge commits now follow semantic commit conventions
- **Better tooling support** - Enables automated changelog generation and version bumping
- **Improved readability** - Clear type (`chore`) and scope (`merge`) for each merge operation
- **Searchable commits** - Easier to filter and find merge-related commits

## Example Output
Instead of: `"Merge environment production"`
Now produces: `"chore(merge): merge environment production"`

Still needs testing and validation

Fixes #100