### PR TITLE
real container resume redux

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -31,8 +31,8 @@ type Environment struct {
 	Services []*Service
 	Notes    Notes
 
-	mu        sync.Mutex
-	container *dagger.Container
+	mu sync.Mutex
+	c  *dagger.Container
 }
 
 func New(ctx context.Context, id, name, worktree string) (*Environment, error) {
@@ -64,7 +64,7 @@ func New(ctx context.Context, id, name, worktree string) (*Environment, error) {
 }
 
 func (env *Environment) Export(ctx context.Context) (rerr error) {
-	_, err := env.container.Directory(env.Config.Workdir).Export(
+	_, err := env.container().Directory(env.Config.Workdir).Export(
 		ctx,
 		env.Worktree,
 		dagger.DirectoryExportOpts{Wipe: true},
@@ -82,7 +82,7 @@ func (env *Environment) Export(ctx context.Context) (rerr error) {
 }
 
 func (env *Environment) State(ctx context.Context) ([]byte, error) {
-	containerID, err := env.container.ID(ctx)
+	containerID, err := env.container().ID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func Load(ctx context.Context, id, name string, state []byte, worktree string) (
 		}
 	}
 
-	env.container = dag.LoadContainerFromID(dagger.ContainerID(st.Container))
+	env.updateContainer(dag.LoadContainerFromID(dagger.ContainerID(st.Container)))
 
 	return env, nil
 }
@@ -134,10 +134,16 @@ func (env *Environment) apply(ctx context.Context, name, explanation, output str
 	return nil
 }
 
+func (env *Environment) container() *dagger.Container {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	return env.c
+}
+
 func (env *Environment) updateContainer(newState *dagger.Container) {
 	env.mu.Lock()
 	defer env.mu.Unlock()
-	env.container = newState
+	env.c = newState
 }
 
 func containerWithEnvAndSecrets(container *dagger.Container, envs, secrets []string) (*dagger.Container, error) {
@@ -167,7 +173,7 @@ func (env *Environment) buildBase(ctx context.Context) (*dagger.Container, error
 	sourceDir, err := dag.
 		Host().
 		Directory(env.Worktree, dagger.HostDirectoryOpts{NoCache: true}). // bust cache for seperate calls (create vs update)
-		Sync(ctx)                                                         // but when restoring from a save, sourceDir changes shouldn't bust cache
+		Sync(ctx)                                                         // but when restoring from a save, sourceDir changes should take the oldest state
 	if err != nil {
 		return nil, fmt.Errorf("failed to load environment source: %w", err)
 	}
@@ -239,7 +245,7 @@ func (env *Environment) Run(ctx context.Context, explanation, command, shell str
 	if command != "" {
 		args = []string{shell, "-c", command}
 	}
-	newState := env.container.WithExec(args, dagger.ContainerWithExecOpts{
+	newState := env.container().WithExec(args, dagger.ContainerWithExecOpts{
 		UseEntrypoint: useEntrypoint,
 	})
 
@@ -267,7 +273,7 @@ func (env *Environment) RunBackground(ctx context.Context, explanation, command,
 	if command != "" {
 		args = []string{shell, "-c", command}
 	}
-	serviceState := env.container
+	serviceState := env.container()
 
 	// Expose ports
 	for _, port := range ports {
@@ -330,7 +336,7 @@ func (env *Environment) RunBackground(ctx context.Context, explanation, command,
 }
 
 func (env *Environment) Terminal(ctx context.Context) error {
-	container := env.container
+	container := env.container()
 	var cmd []string
 	var sourceRC string
 	if shells, err := container.File("/etc/shells").Contents(ctx); err == nil {
@@ -362,5 +368,5 @@ func (env *Environment) Terminal(ctx context.Context) error {
 }
 
 func (env *Environment) Checkpoint(ctx context.Context, target string) (string, error) {
-	return env.container.Publish(ctx, target)
+	return env.container().Publish(ctx, target)
 }

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s *Environment) FileRead(ctx context.Context, targetFile string, shouldReadEntireFile bool, startLineOneIndexed int, endLineOneIndexedInclusive int) (string, error) {
-	file, err := s.container.File(targetFile).Contents(ctx)
+	file, err := s.container().File(targetFile).Contents(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -32,7 +32,7 @@ func (s *Environment) FileRead(ctx context.Context, targetFile string, shouldRea
 }
 
 func (s *Environment) FileWrite(ctx context.Context, explanation, targetFile, contents string) error {
-	err := s.apply(ctx, "Write "+targetFile, explanation, "", s.container.WithNewFile(targetFile, contents))
+	err := s.apply(ctx, "Write "+targetFile, explanation, "", s.container().WithNewFile(targetFile, contents))
 	if err != nil {
 		return fmt.Errorf("failed applying file write, skipping git propogation: %w", err)
 	}
@@ -41,7 +41,7 @@ func (s *Environment) FileWrite(ctx context.Context, explanation, targetFile, co
 }
 
 func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile string) error {
-	err := s.apply(ctx, "Delete "+targetFile, explanation, "", s.container.WithoutFile(targetFile))
+	err := s.apply(ctx, "Delete "+targetFile, explanation, "", s.container().WithoutFile(targetFile))
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func (s *Environment) FileDelete(ctx context.Context, explanation, targetFile st
 }
 
 func (s *Environment) FileList(ctx context.Context, path string) (string, error) {
-	entries, err := s.container.Directory(path).Entries(ctx)
+	entries, err := s.container().Directory(path).Entries(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/environment/service.go
+++ b/environment/service.go
@@ -117,7 +117,7 @@ func (env *Environment) AddService(ctx context.Context, explanation string, cfg 
 	env.Config.Services = append(env.Config.Services, cfg)
 	env.Services = append(env.Services, svc)
 
-	state := env.container.WithServiceBinding(cfg.Name, svc.svc)
+	state := env.container().WithServiceBinding(cfg.Name, svc.svc)
 	if err := env.apply(ctx, "Add service "+cfg.Name, explanation, "", state); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
we incidentally got a bunch of the "real" container resume logic working when @aluzzardi reworked state storage into git. 

this PR shores up a hole in that resume: we weren't saving run commands into the ongoing container state.

the other hole is run_background... maybe that should just call AddService? does that make sense to you @aluzzardi?

this also includes minor fixes to env.container concurrency safety. 