### PR TITLE
docs: add a note about claude code permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ env = {}
 cat ./examples/hello_world.md | claude --dangerously-skip-permissions
 ```
 
+_If you see a "Raw mode is not supported" error then run `claude --dangerously-skip-permissions` directly, accept the terms and try the above command again._
+
 ### Run with [Goose](https://block.github.io/goose/)
 
 ```console


### PR DESCRIPTION
New users might not know that they need to manually accept the permissions before they can run `claude --dangerously-skip-permissions` as part of a piped command.

[Related comment](https://github.com/dagger/container-use/pull/40#issuecomment-2993538457)