### PR TITLE
fix empty file committing & modernize splitseq

### DIFF
--- a/repository/git.go
+++ b/repository/git.go
@@ -273,7 +273,7 @@ func (r *Repository) commitWorktreeChanges(ctx context.Context, worktreePath, na
 	}
 
 	commitMsg := fmt.Sprintf("%s\n\n%s", name, explanation)
-	_, err = runGitCommand(ctx, worktreePath, "commit", "-m", commitMsg)
+	_, err = runGitCommand(ctx, worktreePath, "commit", "--allow-empty", "-m", commitMsg)
 	return err
 }
 

--- a/repository/git.go
+++ b/repository/git.go
@@ -286,9 +286,7 @@ func (r *Repository) addNonBinaryFiles(ctx context.Context, worktreePath string)
 		return err
 	}
 
-	lines := strings.Split(strings.TrimSpace(statusOutput), "\n")
-
-	for _, line := range lines {
+	for line := range strings.SplitSeq(strings.TrimSpace(statusOutput), "\n") {
 		if line == "" {
 			continue
 		}
@@ -394,26 +392,27 @@ func (r *Repository) applyUncommittedChanges(ctx context.Context, worktreePath s
 
 	slog.Info("Applying uncommitted changes to worktree", "repository", r.userRepoPath, "worktree", worktreePath)
 
-	patch, err := runGitCommand(ctx, r.userRepoPath, "diff", "HEAD")
+	trackedFilesPatch, err := runGitCommand(ctx, r.userRepoPath, "diff", "HEAD")
 	if err != nil {
 		return err
 	}
 
-	if strings.TrimSpace(patch) != "" {
+	if strings.TrimSpace(trackedFilesPatch) != "" {
 		cmd := exec.Command("git", "apply")
 		cmd.Dir = worktreePath
-		cmd.Stdin = strings.NewReader(patch)
+		cmd.Stdin = strings.NewReader(trackedFilesPatch)
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("failed to apply patch: %w", err)
 		}
 	}
 
+	// --exclude-standard excludes .gitignored files. those are more likely to be platform-specific, so we don't copy them.
 	untrackedFiles, err := runGitCommand(ctx, r.userRepoPath, "ls-files", "--others", "--exclude-standard")
 	if err != nil {
 		return err
 	}
 
-	for _, file := range strings.Split(strings.TrimSpace(untrackedFiles), "\n") {
+	for file := range strings.SplitSeq(strings.TrimSpace(untrackedFiles), "\n") {
 		if file == "" {
 			continue
 		}
@@ -481,6 +480,11 @@ func (r *Repository) isBinaryFile(worktreePath, fileName string) bool {
 
 	if stat.Size() > maxFileSizeForTextCheck {
 		return true
+	}
+
+	// Empty files should be treated as text files so `touch .gitkeep` and friends work correctly
+	if stat.Size() == 0 {
+		return false
 	}
 
 	file, err := os.Open(fullPath)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -175,7 +175,7 @@ func (r *Repository) List(ctx context.Context) ([]*environment.Environment, erro
 	}
 
 	envs := []*environment.Environment{}
-	for _, branch := range strings.Split(branches, "\n") {
+	for branch := range strings.SplitSeq(branches, "\n") {
 		branch = strings.TrimSpace(branch)
 		// FIXME(aluzzardi): This logic is broken
 		if !strings.Contains(branch, "/") {


### PR DESCRIPTION
`touch .gitkeep` and really any `touch` command creates a weird state where the file might exist and show up in `git status` but not be committed.

also a few renames for clarity and fixed `modernize splitseq` linter.