### PR TITLE
explicit client passing

### DIFF
--- a/cmd/cu/list.go
+++ b/cmd/cu/list.go
@@ -20,13 +20,13 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		envs, err := repo.List(ctx)
+		envInfos, err := repo.List(ctx)
 		if err != nil {
 			return err
 		}
 		if quiet, _ := app.Flags().GetBool("quiet"); quiet {
-			for _, env := range envs {
-				fmt.Println(env.ID)
+			for _, envInfo := range envInfos {
+				fmt.Println(envInfo.ID)
 			}
 			return nil
 		}
@@ -35,8 +35,8 @@ var listCmd = &cobra.Command{
 		fmt.Fprintln(tw, "ID\tTITLE\tCREATED\tUPDATED")
 
 		defer tw.Flush()
-		for _, env := range envs {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", env.ID, truncate(app, env.State.Title, 40), humanize.Time(env.State.CreatedAt), humanize.Time(env.State.UpdatedAt))
+		for _, envInfo := range envInfos {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", envInfo.ID, truncate(app, envInfo.State.Title, 40), humanize.Time(envInfo.State.CreatedAt), humanize.Time(envInfo.State.UpdatedAt))
 		}
 		return nil
 	},

--- a/cmd/cu/main.go
+++ b/cmd/cu/main.go
@@ -12,12 +12,9 @@ import (
 	"syscall"
 
 	"dagger.io/dagger"
-	"github.com/dagger/container-use/environment"
 	"github.com/dagger/container-use/mcpserver"
 	"github.com/spf13/cobra"
 )
-
-var dag *dagger.Client
 
 func dumpStacks() {
 	buf := make([]byte, 1<<20) // 1MB buffer
@@ -41,16 +38,14 @@ var (
 
 			slog.Info("connecting to dagger")
 
-			var err error
-			dag, err = dagger.Connect(ctx, dagger.WithLogOutput(logWriter))
+			client, err := dagger.Connect(ctx, dagger.WithLogOutput(logWriter))
 			if err != nil {
 				slog.Error("Error starting dagger", "error", err)
 				os.Exit(1)
 			}
-			defer dag.Close()
+			defer client.Close()
 
-			environment.Initialize(dag)
-			return mcpserver.RunStdioServer(ctx)
+			return mcpserver.RunStdioServer(ctx, client)
 		},
 	}
 )

--- a/cmd/cu/terminal.go
+++ b/cmd/cu/terminal.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"dagger.io/dagger"
-	"github.com/dagger/container-use/environment"
 	"github.com/dagger/container-use/repository"
 	"github.com/spf13/cobra"
 )
@@ -44,9 +43,7 @@ var terminalCmd = &cobra.Command{
 			return fmt.Errorf("failed to connect to dagger: %w", err)
 		}
 		defer dag.Close()
-		environment.Initialize(dag)
-
-		env, err := repo.Get(ctx, args[0])
+		env, err := repo.Get(ctx, dag, args[0])
 		if err != nil {
 			return err
 		}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -14,19 +14,20 @@ import (
 	"dagger.io/dagger"
 )
 
-var dag *dagger.Client
-
-func Initialize(client *dagger.Client) error {
-	dag = client
-	return nil
-}
-
-type Environment struct {
+// EnvironmentInfo contains basic metadata about an environment
+// without requiring dagger operations
+type EnvironmentInfo struct {
 	Config *EnvironmentConfig
 	State  *State
 
 	ID       string
 	Worktree string
+}
+
+type Environment struct {
+	*EnvironmentInfo
+
+	Client *dagger.Client
 
 	Services []*Service
 	Notes    Notes
@@ -34,16 +35,19 @@ type Environment struct {
 	mu sync.RWMutex
 }
 
-func New(ctx context.Context, id, title, worktree string) (*Environment, error) {
+func New(ctx context.Context, client *dagger.Client, id, title, worktree string) (*Environment, error) {
 	env := &Environment{
-		ID:       id,
-		Worktree: worktree,
-		Config:   DefaultConfig(),
-		State: &State{
-			Title:     title,
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
+		EnvironmentInfo: &EnvironmentInfo{
+			ID:       id,
+			Worktree: worktree,
+			Config:   DefaultConfig(),
+			State: &State{
+				Title:     title,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
 		},
+		Client: client,
 	}
 
 	if err := env.Config.Load(worktree); err != nil {
@@ -88,15 +92,18 @@ func (env *Environment) container() *dagger.Container {
 	env.mu.RLock()
 	defer env.mu.RUnlock()
 
-	return dag.LoadContainerFromID(dagger.ContainerID(env.State.Container))
+	return env.Client.LoadContainerFromID(dagger.ContainerID(env.State.Container))
 }
 
-func Load(ctx context.Context, id string, state []byte, worktree string) (*Environment, error) {
+func Load(ctx context.Context, client *dagger.Client, id string, state []byte, worktree string) (*Environment, error) {
 	env := &Environment{
-		ID:       id,
-		Worktree: worktree,
-		Config:   DefaultConfig(),
-		State:    &State{},
+		EnvironmentInfo: &EnvironmentInfo{
+			ID:       id,
+			Worktree: worktree,
+			Config:   DefaultConfig(),
+			State:    &State{},
+		},
+		Client: client,
 	}
 	if err := env.Config.Load(worktree); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -109,6 +116,29 @@ func Load(ctx context.Context, id string, state []byte, worktree string) (*Envir
 	}
 
 	return env, nil
+}
+
+// LoadInfo loads basic environment metadata without requiring dagger operations.
+// This is useful for operations that only need access to configuration and state
+// information without the overhead of initializing container operations.
+func LoadInfo(ctx context.Context, id string, state []byte, worktree string) (*EnvironmentInfo, error) {
+	envInfo := &EnvironmentInfo{
+		ID:       id,
+		Worktree: worktree,
+		Config:   DefaultConfig(),
+		State:    &State{},
+	}
+	if err := envInfo.Config.Load(worktree); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+
+	if err := envInfo.State.Unmarshal(state); err != nil {
+		return nil, err
+	}
+
+	return envInfo, nil
 }
 
 func (env *Environment) apply(ctx context.Context, name, explanation, output string, newState *dagger.Container) error {
@@ -129,7 +159,7 @@ func (env *Environment) apply(ctx context.Context, name, explanation, output str
 	return nil
 }
 
-func containerWithEnvAndSecrets(container *dagger.Container, envs, secrets []string) (*dagger.Container, error) {
+func containerWithEnvAndSecrets(client *dagger.Client, container *dagger.Container, envs, secrets []string) (*dagger.Container, error) {
 	for _, env := range envs {
 		k, v, found := strings.Cut(env, "=")
 		if !found {
@@ -146,23 +176,23 @@ func containerWithEnvAndSecrets(container *dagger.Container, envs, secrets []str
 		if !found {
 			return nil, fmt.Errorf("invalid secret: %s", secret)
 		}
-		container = container.WithSecretVariable(k, dag.Secret(v))
+		container = container.WithSecretVariable(k, client.Secret(v))
 	}
 
 	return container, nil
 }
 
 func (env *Environment) buildBase(ctx context.Context) (*dagger.Container, error) {
-	sourceDir := dag.Host().Directory(env.Worktree, dagger.HostDirectoryOpts{
+	sourceDir := env.Client.Host().Directory(env.Worktree, dagger.HostDirectoryOpts{
 		NoCache: true,
 	})
 
-	container := dag.
+	container := env.Client.
 		Container().
 		From(env.Config.BaseImage).
 		WithWorkdir(env.Config.Workdir)
 
-	container, err := containerWithEnvAndSecrets(container, env.Config.Env, env.Config.Secrets)
+	container, err := containerWithEnvAndSecrets(env.Client, container, env.Config.Env, env.Config.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +307,7 @@ func (env *Environment) RunBackground(ctx context.Context, explanation, command,
 		endpoints[port] = endpoint
 
 		// Expose port on the host
-		tunnel, err := dag.Host().Tunnel(svc, dagger.HostTunnelOpts{
+		tunnel, err := env.Client.Host().Tunnel(svc, dagger.HostTunnelOpts{
 			Ports: []dagger.PortForward{
 				{
 					Backend:  port,

--- a/environment/service.go
+++ b/environment/service.go
@@ -35,8 +35,8 @@ func (env *Environment) startServices(ctx context.Context) ([]*Service, error) {
 }
 
 func (env *Environment) startService(ctx context.Context, cfg *ServiceConfig) (*Service, error) {
-	container := dag.Container().From(cfg.Image)
-	container, err := containerWithEnvAndSecrets(container, cfg.Env, cfg.Secrets)
+	container := env.Client.Container().From(cfg.Image)
+	container, err := containerWithEnvAndSecrets(env.Client, container, cfg.Env, cfg.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (env *Environment) startService(ctx context.Context, cfg *ServiceConfig) (*
 		endpoints[port] = endpoint
 
 		// Expose ports on the host
-		tunnel, err := dag.Host().Tunnel(svc, dagger.HostTunnelOpts{
+		tunnel, err := env.Client.Host().Tunnel(svc, dagger.HostTunnelOpts{
 			Ports: []dagger.PortForward{
 				{
 					Backend:  port,

--- a/environment/service.go
+++ b/environment/service.go
@@ -35,8 +35,8 @@ func (env *Environment) startServices(ctx context.Context) ([]*Service, error) {
 }
 
 func (env *Environment) startService(ctx context.Context, cfg *ServiceConfig) (*Service, error) {
-	container := env.Client.Container().From(cfg.Image)
-	container, err := containerWithEnvAndSecrets(env.Client, container, cfg.Env, cfg.Secrets)
+	container := env.dag.Container().From(cfg.Image)
+	container, err := containerWithEnvAndSecrets(env.dag, container, cfg.Env, cfg.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (env *Environment) startService(ctx context.Context, cfg *ServiceConfig) (*
 		endpoints[port] = endpoint
 
 		// Expose ports on the host
-		tunnel, err := env.Client.Host().Tunnel(svc, dagger.HostTunnelOpts{
+		tunnel, err := env.dag.Host().Tunnel(svc, dagger.HostTunnelOpts{
 			Ports: []dagger.PortForward{
 				{
 					Backend:  port,

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"dagger.io/dagger"
 	"github.com/dagger/container-use/environment"
 	"github.com/dagger/container-use/repository"
 	"github.com/dagger/container-use/rules"
@@ -35,7 +36,11 @@ func openEnvironment(ctx context.Context, request mcp.CallToolRequest) (*reposit
 	if err != nil {
 		return nil, nil, err
 	}
-	env, err := repo.Get(ctx, envID)
+	client, ok := ctx.Value("dagger_client").(*dagger.Client)
+	if !ok {
+		return nil, nil, fmt.Errorf("dagger client not found in context")
+	}
+	env, err := repo.Get(ctx, client, envID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -47,7 +52,7 @@ type Tool struct {
 	Handler    server.ToolHandlerFunc
 }
 
-func RunStdioServer(ctx context.Context) error {
+func RunStdioServer(ctx context.Context, client *dagger.Client) error {
 	s := server.NewMCPServer(
 		"Dagger",
 		"1.0.0",
@@ -55,7 +60,7 @@ func RunStdioServer(ctx context.Context) error {
 	)
 
 	for _, t := range tools {
-		s.AddTool(t.Definition, t.Handler)
+		s.AddTool(t.Definition, wrapToolWithClient(t, client).Handler)
 	}
 
 	slog.Info("starting server")
@@ -70,15 +75,29 @@ func registerTool(tool ...*Tool) {
 	}
 }
 
-func wrapTool(t *Tool) *Tool {
+func wrapTool(tool *Tool) *Tool {
 	return &Tool{
-		Definition: t.Definition,
-		Handler: func(ctx context.Context, request mcp.CallToolRequest) (_ *mcp.CallToolResult, rerr error) {
-			slog.Info("Calling tool", "tool", t.Definition.Name)
+		Definition: tool.Definition,
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			slog.Info("Tool called", "tool", tool.Definition.Name)
 			defer func() {
-				slog.Info("Tool call completed", "tool", t.Definition.Name, "err", rerr)
+				slog.Info("Tool finished", "tool", tool.Definition.Name)
 			}()
-			return t.Handler(ctx, request)
+			return tool.Handler(ctx, request)
+		},
+	}
+}
+
+func wrapToolWithClient(tool *Tool, client *dagger.Client) *Tool {
+	return &Tool{
+		Definition: tool.Definition,
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			slog.Info("Tool called", "tool", tool.Definition.Name)
+			defer func() {
+				slog.Info("Tool finished", "tool", tool.Definition.Name)
+			}()
+			ctx = context.WithValue(ctx, "dagger_client", client)
+			return tool.Handler(ctx, request)
 		},
 	}
 }
@@ -135,10 +154,38 @@ func marshalEnvironment(env *environment.Environment) (string, error) {
 	return string(out), nil
 }
 
+func marshalEnvironmentInfo(envInfo *environment.EnvironmentInfo) (string, error) {
+	resp := &EnvironmentResponse{
+		ID:              envInfo.ID,
+		Title:           envInfo.State.Title,
+		Instructions:    envInfo.Config.Instructions,
+		BaseImage:       envInfo.Config.BaseImage,
+		SetupCommands:   envInfo.Config.SetupCommands,
+		Workdir:         envInfo.Config.Workdir,
+		RemoteRef:       fmt.Sprintf("container-use/%s", envInfo.ID),
+		CheckoutCommand: fmt.Sprintf("cu checkout %s", envInfo.ID),
+		LogCommand:      fmt.Sprintf("cu log %s", envInfo.ID),
+		Services:        nil, // EnvironmentInfo doesn't have services
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal response: %w", err)
+	}
+	return string(out), nil
+}
+
 func EnvironmentToCallResult(env *environment.Environment) (*mcp.CallToolResult, error) {
 	out, err := marshalEnvironment(env)
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to marshal environment", err), nil
+		return nil, err
+	}
+	return mcp.NewToolResultText(out), nil
+}
+
+func EnvironmentInfoToCallResult(envInfo *environment.EnvironmentInfo) (*mcp.CallToolResult, error) {
+	out, err := marshalEnvironmentInfo(envInfo)
+	if err != nil {
+		return nil, err
 	}
 	return mcp.NewToolResultText(out), nil
 }
@@ -196,7 +243,12 @@ DO NOT manually install toolchains inside the environment, instead explicitly ca
 			return nil, err
 		}
 
-		env, err := repo.Create(ctx, title, request.GetString("explanation", ""))
+		client, ok := ctx.Value("dagger_client").(*dagger.Client)
+		if !ok {
+			return mcp.NewToolResultErrorFromErr("dagger client not found in context", nil), nil
+		}
+
+		env, err := repo.Create(ctx, client, title, request.GetString("explanation", ""))
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("failed to create environment", err), nil
 		}
@@ -331,11 +383,29 @@ var EnvironmentListTool = &Tool{
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("unable to open the repository", err), nil
 		}
-		envs, err := repo.List(ctx)
+		envInfos, err := repo.List(ctx)
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("invalid source", err), nil
 		}
-		out, err := json.Marshal(envs)
+
+		// Convert EnvironmentInfo slice to EnvironmentResponse slice
+		responses := make([]EnvironmentResponse, len(envInfos))
+		for i, envInfo := range envInfos {
+			responses[i] = EnvironmentResponse{
+				ID:              envInfo.ID,
+				Title:           envInfo.State.Title,
+				Instructions:    envInfo.Config.Instructions,
+				BaseImage:       envInfo.Config.BaseImage,
+				SetupCommands:   envInfo.Config.SetupCommands,
+				Workdir:         envInfo.Config.Workdir,
+				RemoteRef:       fmt.Sprintf("container-use/%s", envInfo.ID),
+				CheckoutCommand: fmt.Sprintf("cu checkout %s", envInfo.ID),
+				LogCommand:      fmt.Sprintf("cu log %s", envInfo.ID),
+				Services:        nil, // EnvironmentInfo doesn't have services
+			}
+		}
+
+		out, err := json.Marshal(responses)
 		if err != nil {
 			return nil, err
 		}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"dagger.io/dagger"
 	"github.com/dagger/container-use/environment"
 	petname "github.com/dustinkirkland/golang-petname"
 )
@@ -115,7 +116,31 @@ func (r *Repository) exists(ctx context.Context, id string) error {
 	return nil
 }
 
-func (r *Repository) Get(ctx context.Context, id string) (*environment.Environment, error) {
+// Create creates a new environment with the given description and explanation.
+// Requires a dagger client for container operations during environment initialization.
+func (r *Repository) Create(ctx context.Context, client *dagger.Client, description, explanation string) (*environment.Environment, error) {
+	id := petname.Generate(2, "-")
+	worktree, err := r.initializeWorktree(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := environment.New(ctx, client, id, description, worktree)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.propagateToWorktree(ctx, env, "Create env "+id, explanation); err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+// Get retrieves a full Environment with dagger client embedded for container operations.
+// Use this when you need to perform container operations like running commands, terminals, etc.
+// For basic metadata access without container operations, use Info() instead.
+func (r *Repository) Get(ctx context.Context, client *dagger.Client, id string) (*environment.Environment, error) {
 	if err := r.exists(ctx, id); err != nil {
 		return nil, err
 	}
@@ -130,7 +155,7 @@ func (r *Repository) Get(ctx context.Context, id string) (*environment.Environme
 		return nil, err
 	}
 
-	env, err := environment.Load(ctx, id, state, worktree)
+	env, err := environment.Load(ctx, client, id, state, worktree)
 	if err != nil {
 		return nil, err
 	}
@@ -138,42 +163,42 @@ func (r *Repository) Get(ctx context.Context, id string) (*environment.Environme
 	return env, nil
 }
 
-func (r *Repository) Create(ctx context.Context, description, explanation string) (*environment.Environment, error) {
-	id := petname.Generate(2, "-")
+// Info retrieves basic environment metadata without requiring dagger operations.
+// This is more efficient than Get() when you only need access to configuration,
+// state, and other metadata without performing container operations.
+func (r *Repository) Info(ctx context.Context, id string) (*environment.EnvironmentInfo, error) {
+	if err := r.exists(ctx, id); err != nil {
+		return nil, err
+	}
+
 	worktree, err := r.initializeWorktree(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	env, err := environment.New(ctx, id, description, worktree)
+	state, err := r.loadState(ctx, worktree)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := r.propagateToWorktree(ctx, env, "Create env "+id, explanation); err != nil {
+	envInfo, err := environment.LoadInfo(ctx, id, state, worktree)
+	if err != nil {
 		return nil, err
 	}
 
-	return env, nil
+	return envInfo, nil
 }
 
-func (r *Repository) Update(ctx context.Context, env *environment.Environment, operation, explanation string) error {
-	note := env.Notes.Pop()
-	if strings.TrimSpace(note) != "" {
-		if err := r.addGitNote(ctx, env, note); err != nil {
-			return err
-		}
-	}
-	return r.propagateToWorktree(ctx, env, operation, explanation)
-}
-
-func (r *Repository) List(ctx context.Context) ([]*environment.Environment, error) {
+// List returns basic information about all environments in the repository.
+// Returns EnvironmentInfo slice avoiding dagger client initialization.
+// Use Get() on individual environments when you need full Environment with container operations.
+func (r *Repository) List(ctx context.Context) ([]*environment.EnvironmentInfo, error) {
 	branches, err := runGitCommand(ctx, r.forkRepoPath, "branch", "--format", "%(refname:short)")
 	if err != nil {
 		return nil, err
 	}
 
-	envs := []*environment.Environment{}
+	envs := []*environment.EnvironmentInfo{}
 	for branch := range strings.SplitSeq(branches, "\n") {
 		branch = strings.TrimSpace(branch)
 
@@ -188,15 +213,25 @@ func (r *Repository) List(ctx context.Context) ([]*environment.Environment, erro
 			continue
 		}
 
-		env, err := r.Get(ctx, branch)
+		envInfo, err := r.Info(ctx, branch)
 		if err != nil {
 			return nil, err
 		}
 
-		envs = append(envs, env)
+		envs = append(envs, envInfo)
 	}
 
 	return envs, nil
+}
+
+func (r *Repository) Update(ctx context.Context, env *environment.Environment, operation, explanation string) error {
+	note := env.Notes.Pop()
+	if strings.TrimSpace(note) != "" {
+		if err := r.addGitNote(ctx, env, note); err != nil {
+			return err
+		}
+	}
+	return r.propagateToWorktree(ctx, env, operation, explanation)
 }
 
 func (r *Repository) Delete(ctx context.Context, id string) error {


### PR DESCRIPTION
previously we were using an initialize fn and package globals to pass in the dagger client. this makes the data passing explicit so that we can avoid client initialization when it's unnecessary. 

to get that done, i've introduced an EnvironmentInfo struct that's essentially all the metadata for an environment: config, state, id, and worktree. those can be fetched and marshalled without use of the dagger client. 

Services are kinda the final frontier of this PR... right now they have actual *dagger.Service on them, but ideally we should move the config into environment info and leave the hydrated `[]*dagger.Service` on environment or something like that, but the correct data modeling to get there is not entirely clear to me yet.