### PR TITLE
POC: user-defined environments

### DIFF
--- a/environment/config.go
+++ b/environment/config.go
@@ -17,9 +17,9 @@ const (
 
 func DefaultConfig() *EnvironmentConfig {
 	return &EnvironmentConfig{
-		BaseImage:    defaultImage,
-		Instructions: "No instructions found. Please look around the filesystem and update me",
-		Workdir:      "/workdir",
+		BaseImage: defaultImage,
+		// Instructions: "No instructions found. Please look around the filesystem and update me",
+		Workdir: "/workdir",
 	}
 }
 

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -102,8 +102,8 @@ func wrapToolWithClient(tool *Tool, dag *dagger.Client) *Tool {
 func init() {
 	registerTool(
 		EnvironmentOpenTool,
-		EnvironmentCreateTool,
-		EnvironmentUpdateTool,
+		EnvironmentListTool,
+		// EnvironmentUpdateTool,
 
 		EnvironmentRunCmdTool,
 
@@ -151,8 +151,8 @@ func marshalEnvironment(env *environment.Environment) (string, error) {
 	return string(out), nil
 }
 
-func marshalEnvironmentInfo(envInfo *environment.EnvironmentInfo) (string, error) {
-	resp := &EnvironmentResponse{
+func envInfoToResponse(envInfo *environment.EnvironmentInfo) *EnvironmentResponse {
+	return &EnvironmentResponse{
 		ID:              envInfo.ID,
 		Title:           envInfo.State.Title,
 		Instructions:    envInfo.Config.Instructions,
@@ -164,6 +164,10 @@ func marshalEnvironmentInfo(envInfo *environment.EnvironmentInfo) (string, error
 		LogCommand:      fmt.Sprintf("cu log %s", envInfo.ID),
 		Services:        nil, // EnvironmentInfo doesn't have "active" services, specifically useful for EndpointMappings
 	}
+}
+
+func marshalEnvironmentInfo(envInfo *environment.EnvironmentInfo) (string, error) {
+	resp := envInfoToResponse(envInfo)
 	out, err := json.Marshal(resp)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal response: %w", err)
@@ -189,7 +193,7 @@ func EnvironmentInfoToCallResult(envInfo *environment.EnvironmentInfo) (*mcp.Cal
 
 var EnvironmentOpenTool = &Tool{
 	Definition: mcp.NewTool("environment_open",
-		mcp.WithDescription("Opens an existing environment. Return format is same as environment_create."),
+		mcp.WithDescription("Opens an existing environment. If unsure, use `environment_list` to list available environments."),
 		mcp.WithString("explanation",
 			mcp.Description("One sentence explanation for why this environment is being opened."),
 		),
@@ -245,7 +249,7 @@ DO NOT manually install toolchains inside the environment, instead explicitly ca
 			return mcp.NewToolResultErrorFromErr("dagger client not found in context", nil), nil
 		}
 
-		env, err := repo.Create(ctx, dag, title, request.GetString("explanation", ""))
+		env, err := repo.Create(ctx, dag, "", title, request.GetString("explanation", ""))
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("failed to create environment", err), nil
 		}
@@ -421,7 +425,7 @@ var EnvironmentRunCmdTool = &Tool{
 			mcp.Required(),
 		),
 		mcp.WithString("environment_id",
-			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Description("The ID of the environment for this command."),
 			mcp.Required(),
 		),
 		mcp.WithString("command",
@@ -514,7 +518,7 @@ var EnvironmentFileReadTool = &Tool{
 			mcp.Required(),
 		),
 		mcp.WithString("environment_id",
-			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Description("The ID of the environment for this command."),
 			mcp.Required(),
 		),
 		mcp.WithString("target_file",
@@ -565,7 +569,7 @@ var EnvironmentFileListTool = &Tool{
 			mcp.Required(),
 		),
 		mcp.WithString("environment_id",
-			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Description("The ID of the environment for this command."),
 			mcp.Required(),
 		),
 		mcp.WithString("path",
@@ -604,7 +608,7 @@ var EnvironmentFileWriteTool = &Tool{
 			mcp.Required(),
 		),
 		mcp.WithString("environment_id",
-			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Description("The ID of the environment for this command."),
 			mcp.Required(),
 		),
 		mcp.WithString("target_file",
@@ -654,7 +658,7 @@ var EnvironmentFileDeleteTool = &Tool{
 			mcp.Required(),
 		),
 		mcp.WithString("environment_id",
-			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Description("The ID of the environment for this command."),
 			mcp.Required(),
 		),
 		mcp.WithString("target_file",
@@ -692,7 +696,7 @@ var EnvironmentCheckpointTool = &Tool{
 			mcp.Description("One sentence explanation for why this checkpoint is being created."),
 		),
 		mcp.WithString("environment_id",
-			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Description("The ID of the environment for this command."),
 			mcp.Required(),
 		),
 		mcp.WithString("destination",
@@ -729,7 +733,7 @@ var EnvironmentAddServiceTool = &Tool{
 			mcp.Required(),
 		),
 		mcp.WithString("environment_id",
-			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Description("The ID of the environment for this command."),
 			mcp.Required(),
 		),
 		mcp.WithString("name",

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -118,8 +118,11 @@ func (r *Repository) exists(ctx context.Context, id string) error {
 
 // Create creates a new environment with the given description and explanation.
 // Requires a dagger client for container operations during environment initialization.
-func (r *Repository) Create(ctx context.Context, dag *dagger.Client, description, explanation string) (*environment.Environment, error) {
-	id := petname.Generate(2, "-")
+func (r *Repository) Create(ctx context.Context, dag *dagger.Client, id, description, explanation string) (*environment.Environment, error) {
+	if id == "" {
+		id = petname.Generate(2, "-")
+	}
+
 	worktree, err := r.initializeWorktree(ctx, id)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Just a POC to play around "user defined environments".

The idea is:

- Every cu installation gets a default environment (stateful)
- Agents work on that environment, proposing changes, with the user reviewing/merging
- New sessions automatically resume work in said environment
- In a multi agent scenario, or experimentation scenario, the user could create a different environment and lead the agent there

```sh
# this should happen behind the scenes
$ cu create default

$ goose run --debug -s -t "create a hello world application using flask and a stunning blue design" 
─── environment_list | container-use ──────────────────────────
─── environment_open | container-use ──────────────────────────
environment_id: default
...

$  goose run --debug -s -t "start the hello world app" 
─── environment_list | container-use ──────────────────────────
I see there's a default environment available. Let me open it and check what's inside.
─── environment_open | container-use ──────────────────────────
environment_id: default
Let me check the contents of the environment to find the hello world application.
─── environment_file_list | container-use ──────────────────────────
Now I'll start the application using Python. Since this is a web application that needs to run continuously, I'll run it in the background:
─── environment_run_cmd | container-use ──────────────────────────
background: true
```