### PR TITLE
shell completion installs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,7 @@ project_name: container-use
 before:
   hooks:
     - go mod tidy
+    - ./scripts/completions.sh
 
 builds:
   - id: cu
@@ -34,6 +35,7 @@ archives:
     files:
       - README.md
       - LICENSE
+      - completions/*
 
 homebrew_casks:
   - repository:
@@ -53,9 +55,14 @@ homebrew_casks:
       template: "https://github.com/{{ .Env.GH_ORG_NAME }}/container-use/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     homepage: "https://github.com/{{ .Env.GH_ORG_NAME }}/container-use"
     description: "Containerized environments for coding agents"
+    completions:
+      bash: "completions/cu.bash"
+      zsh: "completions/cu.zsh"
+      fish: "completions/cu.fish"
     hooks:
       post:
         install: |
+          # remove quarantine xattr (note we don't do anything with signatures yet)
           if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cu"]
           end

--- a/README.md
+++ b/README.md
@@ -35,17 +35,13 @@ It's an open-source MCP server that works as a CLI tool with Claude Code, Cursor
 
 ## Install
 
-### macOS (Homebrew - Recommended)
+### Homebrew (Recommended for MacOS)
 
 ```sh
 brew install dagger/tap/container-use
 ```
 
-(Optional) Install shell completions:
-
-```sh
-cu completion bash > $(brew --prefix)/etc/bash_completion.d/container-use
-```
+Our tap should install shell completions for you.
 
 ### All Platforms (Shell Script)
 
@@ -53,13 +49,7 @@ cu completion bash > $(brew --prefix)/etc/bash_completion.d/container-use
 curl -fsSL https://raw.githubusercontent.com/dagger/container-use/main/install.sh | bash
 ```
 
-This will check for Docker & Git (required), detect your platform, and install the latest `cu` binary to your `$PATH`.
-
-(Optional) Install shell completions:
-
-```sh
-cu completion bash > /etc/bash_completion.d/container-use
-```
+This will check for Docker & Git (required), detect your platform, install the latest `cu` binary to your `$PATH`, and provide completion installation instructions.
 
 For building from source, see [CONTRIBUTING.md](CONTRIBUTING.md#building).
 

--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,18 @@ get_latest_version() {
     curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
+# Show shell completion setup instructions
+show_completion_instructions() {
+    local binary="$1"
+
+    log_info "To enable shell completions, run:"
+    echo "  Bash (with bash-completion): $binary completion bash > ~/.local/share/bash-completion/completions/cu"
+    echo "  Bash (unconfigured): echo 'source <($binary completion bash)' >> ~/.bashrc"
+    echo "  Zsh (with compinit and a writable fpath[1]):  $binary completion zsh > \"\${fpath[1]}/_cu\""
+    echo "  Zsh (unconfigured):  echo 'source <($binary completion bash)' >> ~/.zshrc"
+    echo "  Fish: $binary completion fish > ~/.config/fish/completions/cu.fish"
+}
+
 # Verify checksum of downloaded file
 verify_checksum() {
     local archive_file="$1"
@@ -280,6 +292,9 @@ main() {
     # Verify installation
     if [ -x "$INSTALL_DIR/$BINARY_NAME" ]; then
         log_success "Installation complete!"
+
+        # Show shell completion instructions
+        show_completion_instructions "$BINARY_NAME"
 
         # Check if the correct cu command is being found in PATH
         local found_binary=$(command -v "$BINARY_NAME" 2>/dev/null || echo "")

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+rm -rf completions
+mkdir completions
+for sh in bash zsh fish; do
+	go run ./cmd/cu completion "$sh" >"completions/cu.$sh"
+done


### PR DESCRIPTION
requires #130 

this PR installs shell completions using homebrew post install hooks and provides instructions on how to install them as install.sh output.

complexities:
- bash: there are canonical locations for bash, but those locations require the (very standard) [bash-completion](https://github.com/scop/bash-completion#q-where-should-i-install-my-own-local-completions) plugin.
   - in homebrew, we'll just assume you have that package or if you're using bash over default zsh, you'll guess that you need it.
- zsh: there are no canonical locations, but you can look up locations from fpath if your shell is all configured (ohmyzsh, antigen, etc). 
   - homebrew [documents](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh) how things need to be set up for zsh completions, and so long as the user has `eval "$(brew shellenv)"` in their zshrc, we can write to `$(brew --prefix)/share/zsh/site-functions` pretty blindly
- fish is friendly so it's got canonical paths 🎉 

because it's complex to detect what zsh/bash setups a given installer has from inside the installer script, we instead have the install script tell users both the "dumb" rc-centric way to install, and the most common "managed" way.

one alternative approach that folks have talked about is putting this in a `cu init` subcommand or similar. we could do that, but it has all the same difficulties that come with putting this in autoinstalling from our bash-specific install script. there are too many possible shells, userspace package managers, and plugin frameworks and custom configurations (including the absence of them).

NOTE: i haven't tested the homebrew tap, don't merge this without testing it on a fork