### PR TITLE
cu diff

### DIFF
--- a/cmd/cu/diff.go
+++ b/cmd/cu/diff.go
@@ -7,9 +7,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logCmd = &cobra.Command{
-	Use:               "log <env>",
-	Short:             "Show the log for an environment",
+var diffCmd = &cobra.Command{
+	Use:               "diff <env>",
+	Short:             "Show changes between the environment and the local branch",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: suggestEnvironments,
 	RunE: func(app *cobra.Command, args []string) error {
@@ -21,13 +21,10 @@ var logCmd = &cobra.Command{
 			return err
 		}
 
-		patch, _ := app.Flags().GetBool("patch")
-
-		return repo.Log(ctx, args[0], patch, os.Stdout)
+		return repo.Diff(ctx, args[0], os.Stdout)
 	},
 }
 
 func init() {
-	logCmd.Flags().BoolP("patch", "p", false, "Generate patch")
-	rootCmd.AddCommand(logCmd)
+	rootCmd.AddCommand(diffCmd)
 }

--- a/environment/integration/repository_test.go
+++ b/environment/integration/repository_test.go
@@ -143,8 +143,8 @@ func TestRepositoryLog(t *testing.T) {
 		// Get commit log without patches
 		var logBuf bytes.Buffer
 		err := repo.Log(ctx, env.ID, false, &logBuf)
-		require.NoError(t, err)
 		logOutput := logBuf.String()
+		require.NoError(t, err, logOutput)
 
 		// Verify commit messages are present
 		assert.Contains(t, logOutput, "Add second file")

--- a/environment/integration/repository_test.go
+++ b/environment/integration/repository_test.go
@@ -185,8 +185,8 @@ func TestRepositoryDiff(t *testing.T) {
 		// Get diff output
 		var diffBuf bytes.Buffer
 		err := repo.Diff(ctx, env.ID, &diffBuf)
-		require.NoError(t, err)
 		diffOutput := diffBuf.String()
+		require.NoError(t, err, diffOutput)
 
 		// Verify diff contains expected changes
 		assert.Contains(t, diffOutput, "+updated content")

--- a/environment/integration/repository_test.go
+++ b/environment/integration/repository_test.go
@@ -154,8 +154,8 @@ func TestRepositoryLog(t *testing.T) {
 		// Get commit log with patches
 		logBuf.Reset()
 		err = repo.Log(ctx, env.ID, true, &logBuf)
-		require.NoError(t, err)
 		logWithPatchOutput := logBuf.String()
+		require.NoError(t, err, logWithPatchOutput)
 
 		// Verify patch information is included
 		assert.Contains(t, logWithPatchOutput, "diff --git")

--- a/environment/integration/repository_test.go
+++ b/environment/integration/repository_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"strings"
@@ -124,5 +125,74 @@ func TestRepositoryCheckout(t *testing.T) {
 		actualBranch := strings.TrimSpace(currentBranch)
 		assert.True(t, actualBranch == env.ID || actualBranch == "cu-"+env.ID,
 			"Expected branch to be %s or cu-%s, got %s", env.ID, env.ID, actualBranch)
+	})
+}
+
+// TestRepositoryLog tests retrieving commit history for an environment
+func TestRepositoryLog(t *testing.T) {
+	t.Parallel()
+	WithRepository(t, "repository-log", SetupEmptyRepo, func(t *testing.T, repo *repository.Repository, user *UserActions) {
+		ctx := context.Background()
+
+		// Create an environment and add some commits
+		env := user.CreateEnvironment("Test Log", "Testing repository log")
+		user.FileWrite(env.ID, "file1.txt", "initial content", "Initial commit")
+		user.FileWrite(env.ID, "file1.txt", "updated content", "Update file")
+		user.FileWrite(env.ID, "file2.txt", "new file", "Add second file")
+
+		// Get commit log without patches
+		var logBuf bytes.Buffer
+		err := repo.Log(ctx, env.ID, false, &logBuf)
+		require.NoError(t, err)
+		logOutput := logBuf.String()
+
+		// Verify commit messages are present
+		assert.Contains(t, logOutput, "Add second file")
+		assert.Contains(t, logOutput, "Update file")
+		assert.Contains(t, logOutput, "Initial commit")
+
+		// Get commit log with patches
+		logBuf.Reset()
+		err = repo.Log(ctx, env.ID, true, &logBuf)
+		require.NoError(t, err)
+		logWithPatchOutput := logBuf.String()
+
+		// Verify patch information is included
+		assert.Contains(t, logWithPatchOutput, "diff --git")
+		assert.Contains(t, logWithPatchOutput, "+updated content")
+
+		// Test log for non-existent environment
+		err = repo.Log(ctx, "non-existent-env", false, &logBuf)
+		assert.Error(t, err)
+	})
+}
+
+// TestRepositoryDiff tests retrieving changes between commits
+func TestRepositoryDiff(t *testing.T) {
+	t.Parallel()
+	WithRepository(t, "repository-diff", SetupEmptyRepo, func(t *testing.T, repo *repository.Repository, user *UserActions) {
+		ctx := context.Background()
+
+		// Create an environment and make some changes
+		env := user.CreateEnvironment("Test Diff", "Testing repository diff")
+
+		// First commit - add a file
+		user.FileWrite(env.ID, "test.txt", "initial content\n", "Initial commit")
+
+		// Make changes to the file
+		user.FileWrite(env.ID, "test.txt", "initial content\nupdated content\n", "Update file")
+
+		// Get diff output
+		var diffBuf bytes.Buffer
+		err := repo.Diff(ctx, env.ID, &diffBuf)
+		require.NoError(t, err)
+		diffOutput := diffBuf.String()
+
+		// Verify diff contains expected changes
+		assert.Contains(t, diffOutput, "+updated content")
+
+		// Test diff with non-existent environment
+		err = repo.Diff(ctx, "non-existent-env", &diffBuf)
+		assert.Error(t, err)
 	})
 }

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -128,6 +128,7 @@ type EnvironmentResponse struct {
 	RemoteRef       string                 `json:"remote_ref"`
 	CheckoutCommand string                 `json:"checkout_command_to_share_with_user"`
 	LogCommand      string                 `json:"log_command_to_share_with_user"`
+	DiffCommand     string                 `json:"diff_command_to_share_with_user"`
 	Services        []*environment.Service `json:"services,omitempty"`
 }
 
@@ -142,6 +143,7 @@ func marshalEnvironment(env *environment.Environment) (string, error) {
 		RemoteRef:       fmt.Sprintf("container-use/%s", env.ID),
 		CheckoutCommand: fmt.Sprintf("cu checkout %s", env.ID),
 		LogCommand:      fmt.Sprintf("cu log %s", env.ID),
+		DiffCommand:     fmt.Sprintf("cu diff %s", env.ID),
 		Services:        env.Services,
 	}
 	out, err := json.Marshal(resp)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -353,4 +354,61 @@ func (r *Repository) Checkout(ctx context.Context, id, branch string) (string, e
 	}
 
 	return branch, err
+}
+
+func (r *Repository) Log(ctx context.Context, id string, patch bool, w io.Writer) error {
+	envInfo, err := r.Info(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	logArgs := []string{
+		"git",
+		"log",
+		fmt.Sprintf("--notes=%s", gitNotesLogRef),
+	}
+
+	if patch {
+		logArgs = append(logArgs, "--patch")
+	}
+
+	revisionRange, err := r.revisionRange(ctx, envInfo)
+	if err != nil {
+		return err
+	}
+
+	logArgs = append(logArgs, revisionRange)
+
+	cmd := exec.CommandContext(ctx, "git")
+	cmd.Dir = r.userRepoPath
+	cmd.Args = logArgs
+	cmd.Stdout = w
+
+	return cmd.Run()
+}
+
+func (r *Repository) Diff(ctx context.Context, id string, w io.Writer) error {
+	envInfo, err := r.Info(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	diffArgs := []string{
+		"git",
+		"diff",
+	}
+
+	revisionRange, err := r.revisionRange(ctx, envInfo)
+	if err != nil {
+		return err
+	}
+
+	diffArgs = append(diffArgs, revisionRange)
+
+	cmd := exec.CommandContext(ctx, "git")
+	cmd.Dir = r.userRepoPath
+	cmd.Args = diffArgs
+	cmd.Stdout = w
+
+	return cmd.Run()
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -383,6 +383,7 @@ func (r *Repository) Log(ctx context.Context, id string, patch bool, w io.Writer
 	cmd.Dir = r.userRepoPath
 	cmd.Args = logArgs
 	cmd.Stdout = w
+	cmd.Stderr = w
 
 	return cmd.Run()
 }
@@ -409,6 +410,7 @@ func (r *Repository) Diff(ctx context.Context, id string, w io.Writer) error {
 	cmd.Dir = r.userRepoPath
 	cmd.Args = diffArgs
 	cmd.Stdout = w
+	cmd.Stderr = w
 
 	return cmd.Run()
 }


### PR DESCRIPTION
- Add support for `cu diff`
- Only show logs and diffs for changes that happened in the environment
- Move `cu log` code into Repository
- Add `cu log -p` and don't show patches by default
- Show notes in `cu log`
