### PR TITLE
add some optional issue templates for bug reporters

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,30 @@
+name: Bug Report
+description: Report a bug
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Brief description of the issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: Run `cu version` and paste the output
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Contents of `/tmp/cu.debug.stderr.log` (or `$CU_STDERR_FILE` if set)
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,9 @@
+---
 blank_issues_enabled: true
-contact_links: []
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/YXbtwRQv
+    about: Join our Discord for questions and community support
+  - name: Documentation
+    url: https://container-use.com/quickstart
+    about: Check out our setup guide and documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature Request
+description: Suggest a new feature
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What feature would you like?
+      description: Brief description of the feature you'd like to see
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why would this be useful?
+      description: How would this feature help you or others?
+    validations:
+      required: true


### PR DESCRIPTION
this adds a bug report and feature request template to encourage folks to give us logs and `cu version` output, but leaves blank issues enabled for all the cases where tempplates generate annoying boilerplate.