### PR TITLE
test: extract CLI core logic into shared operations

### DIFF
--- a/cmd/cli/operations.go
+++ b/cmd/cli/operations.go
@@ -1,0 +1,81 @@
+// Package cli contains the core logic for container-use CLI commands.
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/container-use/environment"
+	"github.com/dagger/container-use/repository"
+)
+
+// DeleteEnvironments deletes one or more environments.
+func DeleteEnvironments(ctx context.Context, repoPath string, envIDs []string) error {
+	for _, envID := range envIDs {
+		repo, err := repository.Open(ctx, repoPath)
+		if err != nil {
+			return fmt.Errorf("failed to open repository: %w", err)
+		}
+		if err := repo.Delete(ctx, envID); err != nil {
+			return fmt.Errorf("failed to delete environment: %w", err)
+		}
+		fmt.Printf("Environment '%s' deleted successfully.\n", envID)
+	}
+	return nil
+}
+
+// ListEnvironments returns all environments in the repository.
+func ListEnvironments(ctx context.Context, repoPath string) ([]*environment.EnvironmentInfo, error) {
+	repo, err := repository.Open(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	return repo.List(ctx)
+}
+
+// CheckoutEnvironment switches to the git branch for an environment.
+func CheckoutEnvironment(ctx context.Context, repoPath string, envID, branch string) (string, error) {
+	repo, err := repository.Open(ctx, repoPath)
+	if err != nil {
+		return "", err
+	}
+	return repo.Checkout(ctx, envID, branch)
+}
+
+// GetEnvironmentLog returns git log for an environment (test helper).
+func GetEnvironmentLog(ctx context.Context, repoPath string, envID string) (string, error) {
+	if _, err := repository.Open(ctx, repoPath); err != nil {
+		return "", err
+	}
+
+	ref := fmt.Sprintf("container-use/%s", envID)
+	return repository.RunGitCommand(ctx, repoPath, "log", "--oneline", "-10", ref)
+}
+
+// MergeEnvironment performs a non-interactive merge (test helper).
+func MergeEnvironment(ctx context.Context, repoPath string, envID string) error {
+	repo, err := repository.Open(ctx, repoPath)
+	if err != nil {
+		return err
+	}
+
+	envs, err := repo.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for _, env := range envs {
+		if env.ID == envID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("environment %s not found", envID)
+	}
+
+	ref := fmt.Sprintf("container-use/%s", envID)
+	_, err = repository.RunGitCommand(ctx, repoPath, "merge", "--no-edit", ref)
+	return err
+}

--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/dagger/container-use/repository"
+	"github.com/dagger/container-use/cmd/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -16,18 +16,12 @@ var checkoutCmd = &cobra.Command{
 		ctx := app.Context()
 		envID := args[0]
 
-		// Ensure we're in a git repository
-		repo, err := repository.Open(ctx, ".")
-		if err != nil {
-			return err
-		}
-
 		branchName, err := app.Flags().GetString("branch")
 		if err != nil {
 			return err
 		}
 
-		branch, err := repo.Checkout(ctx, envID, branchName)
+		branch, err := cli.CheckoutEnvironment(ctx, ".", envID, branchName)
 		if err != nil {
 			return err
 		}

--- a/cmd/cu/delete.go
+++ b/cmd/cu/delete.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
-
-	"github.com/dagger/container-use/repository"
+	"github.com/dagger/container-use/cmd/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -14,20 +12,7 @@ var deleteCmd = &cobra.Command{
 	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: suggestEnvironments,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-
-		for _, envID := range args {
-			repo, err := repository.Open(ctx, ".")
-			if err != nil {
-				return fmt.Errorf("failed to open repository: %w", err)
-			}
-			if err := repo.Delete(ctx, envID); err != nil {
-				return fmt.Errorf("failed to delete environment: %w", err)
-			}
-
-			fmt.Printf("Environment '%s' deleted successfully.\n", envID)
-		}
-		return nil
+		return cli.DeleteEnvironments(cmd.Context(), ".", args)
 	},
 }
 

--- a/cmd/cu/list.go
+++ b/cmd/cu/list.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/dagger/container-use/repository"
+	"github.com/dagger/container-use/cmd/cli"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
@@ -15,15 +15,11 @@ var listCmd = &cobra.Command{
 	Short: "List environments",
 	Long:  `List environments filtering the git remotes`,
 	RunE: func(app *cobra.Command, _ []string) error {
-		ctx := app.Context()
-		repo, err := repository.Open(ctx, ".")
+		envInfos, err := cli.ListEnvironments(app.Context(), ".")
 		if err != nil {
 			return err
 		}
-		envInfos, err := repo.List(ctx)
-		if err != nil {
-			return err
-		}
+
 		if quiet, _ := app.Flags().GetBool("quiet"); quiet {
 			for _, envInfo := range envInfos {
 				fmt.Println(envInfo.ID)

--- a/environment/integration/helpers.go
+++ b/environment/integration/helpers.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/container-use/cmd/cli"
 	"github.com/dagger/container-use/environment"
 	"github.com/dagger/container-use/repository"
 	"github.com/stretchr/testify/assert"
@@ -333,4 +334,32 @@ func (u *UserActions) GitCommand(args ...string) string {
 	output, err := repository.RunGitCommand(u.ctx, u.repoDir, args...)
 	require.NoError(u.t, err, "Git command failed: %v", args)
 	return output
+}
+
+// CLI operations - these test the actual command implementations
+
+func (u *UserActions) CLIDelete(envID string) error {
+	// TODO: Remove after #157 - context will be set in WithRepository
+	ctx := context.WithValue(u.ctx, "container_use_base_path", u.configDir)
+	return cli.DeleteEnvironments(ctx, u.repoDir, []string{envID})
+}
+
+func (u *UserActions) CLIList() ([]*environment.EnvironmentInfo, error) {
+	// TODO: Remove after #157 - context will be set in WithRepository
+	ctx := context.WithValue(u.ctx, "container_use_base_path", u.configDir)
+	return cli.ListEnvironments(ctx, u.repoDir)
+}
+
+func (u *UserActions) CLICheckout(envID, branchName string) (string, error) {
+	// TODO: Remove after #157 - context will be set in WithRepository
+	ctx := context.WithValue(u.ctx, "container_use_base_path", u.configDir)
+	return cli.CheckoutEnvironment(ctx, u.repoDir, envID, branchName)
+}
+
+func (u *UserActions) CLILog(envID string) (string, error) {
+	return cli.GetEnvironmentLog(u.ctx, u.repoDir, envID)
+}
+
+func (u *UserActions) CLIMerge(envID string) error {
+	return cli.MergeEnvironment(u.ctx, u.repoDir, envID)
 }


### PR DESCRIPTION
⚠️ Must be a follow-up of #157 

The CLI commands (delete, list, checkout) had their core logic directly embedded in the cobra command handlers. This made it impossible to test the actual CLI behavior from integration tests without duplicating the implementation.

This PR extracts the core operations into a new `cmd/cli/operations.go` package that can be used by both:
  - The CLI commands themselves
  - The tests relying on this interface

The extraction is straightforward - each operation keeps the same logic but moves to a shared function. This allows tests to call the exact same code that users execute via `cu delete`, `cu list`, etc.

This change is particularly important for testing bugs like #110 where we need to verify the actual CLI behavior, not a test-specific reimplementation.