### PR TITLE
Best effort env config loading

### DIFF
--- a/environment/config.go
+++ b/environment/config.go
@@ -89,17 +89,21 @@ func (config *EnvironmentConfig) Load(baseDir string) error {
 	configPath := path.Join(baseDir, configDir)
 
 	instructions, err := os.ReadFile(path.Join(configPath, instructionsFile))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	config.Instructions = string(instructions)
+	if err == nil {
+		config.Instructions = string(instructions)
+	}
 
 	data, err := os.ReadFile(path.Join(configPath, environmentFile))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if err := json.Unmarshal(data, config); err != nil {
-		return err
+	if err == nil {
+		if err := json.Unmarshal(data, config); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/environment/config_test.go
+++ b/environment/config_test.go
@@ -1,0 +1,130 @@
+package environment
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnvironmentConfig_Load verifies the best-effort loading behavior
+// The Load method should gracefully handle missing files while still failing on actual errors
+func TestEnvironmentConfig_Load(t *testing.T) {
+	scenarios := []struct {
+		name               string
+		setup              func(t *testing.T, dir string)
+		expectError        bool
+		expectInstructions string
+		expectBaseImage    string
+		expectWorkdir      string
+	}{
+		{
+			name:               "both_files_missing",
+			setup:              func(t *testing.T, dir string) {}, // no setup
+			expectError:        false,
+			expectInstructions: "No instructions found. Please look around the filesystem and update me",
+			expectBaseImage:    "ubuntu:24.04",
+			expectWorkdir:      "/workdir",
+		},
+		{
+			name: "only_instructions_missing",
+			setup: func(t *testing.T, dir string) {
+				createConfigFile(t, dir, &EnvironmentConfig{
+					BaseImage: "custom:image",
+					Workdir:   "/custom",
+				})
+			},
+			expectError:        false,
+			expectInstructions: "No instructions found. Please look around the filesystem and update me",
+			expectBaseImage:    "custom:image",
+			expectWorkdir:      "/custom",
+		},
+		{
+			name: "only_environment_missing",
+			setup: func(t *testing.T, dir string) {
+				createInstructionsFile(t, dir, "Custom instructions")
+			},
+			expectError:        false,
+			expectInstructions: "Custom instructions",
+			expectBaseImage:    "ubuntu:24.04",
+			expectWorkdir:      "/workdir",
+		},
+		{
+			name: "both_files_present",
+			setup: func(t *testing.T, dir string) {
+				createInstructionsFile(t, dir, "Test instructions")
+				createConfigFile(t, dir, &EnvironmentConfig{
+					BaseImage: "test:image",
+					Workdir:   "/test",
+				})
+			},
+			expectError:        false,
+			expectInstructions: "Test instructions",
+			expectBaseImage:    "test:image",
+			expectWorkdir:      "/test",
+		},
+		{
+			name: "invalid_json",
+			setup: func(t *testing.T, dir string) {
+				configDir := filepath.Join(dir, ".container-use")
+				require.NoError(t, os.MkdirAll(configDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "environment.json"), []byte("invalid json"), 0644))
+			},
+			expectError: true,
+		},
+		{
+			name: "config_directory_permission_error",
+			setup: func(t *testing.T, dir string) {
+				if os.Getuid() == 0 {
+					t.Skip("Skipping permission test as root")
+				}
+				configDir := filepath.Join(dir, ".container-use")
+				require.NoError(t, os.MkdirAll(configDir, 0000))
+				t.Cleanup(func() { os.Chmod(configDir, 0755) })
+			},
+			expectError: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			config := DefaultConfig()
+
+			scenario.setup(t, tempDir)
+
+			err := config.Load(tempDir)
+
+			if scenario.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, scenario.expectInstructions, config.Instructions)
+			assert.Equal(t, scenario.expectBaseImage, config.BaseImage)
+			assert.Equal(t, scenario.expectWorkdir, config.Workdir)
+		})
+	}
+}
+
+// Test helper functions
+func createInstructionsFile(t *testing.T, dir, content string) {
+	t.Helper()
+	configDir := filepath.Join(dir, ".container-use")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "AGENT.md"), []byte(content), 0644))
+}
+
+func createConfigFile(t *testing.T, dir string, config *EnvironmentConfig) {
+	t.Helper()
+	configDir := filepath.Join(dir, ".container-use")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "environment.json"), data, 0644))
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -52,9 +51,7 @@ func New(ctx context.Context, dag *dagger.Client, id, title, worktree string, in
 	}
 
 	if err := env.Config.Load(worktree); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	container, err := env.buildBase(ctx, initialSourceDir)
@@ -121,9 +118,7 @@ func LoadInfo(ctx context.Context, id string, state []byte, worktree string) (*E
 		State:    &State{},
 	}
 	if err := envInfo.Config.Load(worktree); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	if err := envInfo.State.Unmarshal(state); err != nil {


### PR DESCRIPTION
fixes #123 

previously we were returning early in the case where the instructions.md was missing but the user had provided the environment.json file. this fixes that bug and adds some unit tests.