### PR TITLE
make logs optional in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,4 +27,4 @@ body:
       description: Contents of `/tmp/cu.debug.stderr.log` (or `$CU_STDERR_FILE` if set)
       render: text
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
not every bug needs the internal logs, just the mysterious ones