### PR TITLE
add flag push remote in checkout command 

### DIFF
--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -8,8 +8,8 @@ import (
 )
 
 var checkoutCmd = &cobra.Command{
-	Use:   "checkout <env>",
-	Short: "Switch to an environment's branch locally",
+	Use:               "checkout <env>",
+	Short:             "Switch to an environment's branch locally",
 	Long: `Bring an environment's work into your local git workspace.
 This creates a local branch from the environment's state so you can
 explore files in your IDE, make changes, or continue development.`,

--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -61,7 +61,7 @@ cu checkout fancy-mallard -b my-review-branch`,
 
 func init() {
 	checkoutCmd.Flags().StringP("branch", "b", "", "Local branch name to use")
-	checkoutCmd.Flags().BoolP("push", "p", false, "Push the checked out branch to origin remote")
+	checkoutCmd.Flags().BoolP("push", "p", false, "Push checkout branch to origin")
 
 	rootCmd.AddCommand(checkoutCmd)
 }

--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -40,6 +40,8 @@ cu checkout fancy-mallard -b my-review-branch`,
 			return err
 		}
 
+		fmt.Printf("Switched to branch '%s'\n", branch)
+
 		pushToRemote, err := app.Flags().GetBool("push")
 		if err != nil {
 			return err
@@ -50,9 +52,9 @@ cu checkout fancy-mallard -b my-review-branch`,
 			if err != nil {
 				return err
 			}
+			fmt.Printf("Pushed branch '%s' to origin\n", branch)
 		}
 
-		fmt.Printf("Switched to branch '%s'\n", branch)
 		return nil
 	},
 }

--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -8,8 +8,8 @@ import (
 )
 
 var checkoutCmd = &cobra.Command{
-	Use:               "checkout <env>",
-	Short:             "Switch to an environment's branch locally",
+	Use:   "checkout <env>",
+	Short: "Switch to an environment's branch locally",
 	Long: `Bring an environment's work into your local git workspace.
 This creates a local branch from the environment's state so you can
 explore files in your IDE, make changes, or continue development.`,
@@ -40,6 +40,18 @@ cu checkout fancy-mallard -b my-review-branch`,
 			return err
 		}
 
+		pushToRemote, err := app.Flags().GetBool("push")
+		if err != nil {
+			return err
+		}
+
+		if pushToRemote {
+			err = repo.PushBranchOrigin(ctx, branch)
+			if err != nil {
+				return err
+			}
+		}
+
 		fmt.Printf("Switched to branch '%s'\n", branch)
 		return nil
 	},
@@ -47,5 +59,7 @@ cu checkout fancy-mallard -b my-review-branch`,
 
 func init() {
 	checkoutCmd.Flags().StringP("branch", "b", "", "Local branch name to use")
+	checkoutCmd.Flags().BoolP("push", "p", false, "Push the checked out branch to origin remote")
+
 	rootCmd.AddCommand(checkoutCmd)
 }

--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -62,6 +62,5 @@ cu checkout fancy-mallard -b my-review-branch`,
 func init() {
 	checkoutCmd.Flags().StringP("branch", "b", "", "Local branch name to use")
 	checkoutCmd.Flags().BoolP("push", "p", false, "Push checkout branch to origin")
-
 	rootCmd.AddCommand(checkoutCmd)
 }

--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -48,7 +48,7 @@ cu checkout fancy-mallard -b my-review-branch`,
 		}
 
 		if pushToRemote {
-			err = repo.PushBranchOrigin(ctx, branch)
+			err = repo.PushBranchToOrigin(ctx, branch)
 			if err != nil {
 				return err
 			}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -414,3 +414,22 @@ func (r *Repository) Diff(ctx context.Context, id string, w io.Writer) error {
 
 	return cmd.Run()
 }
+
+func (r *Repository) PushBranchOrigin(ctx context.Context, branch string) error {
+	_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "get-url", "origin")
+	if err != nil {
+		return err
+	}
+
+	_, err = RunGitCommand(ctx, r.userRepoPath, "rev-parse", "--verify", branch)
+	if err != nil {
+		return err
+	}
+
+	_, err = RunGitCommand(ctx, r.userRepoPath, "push", "origin", branch)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -415,7 +415,7 @@ func (r *Repository) Diff(ctx context.Context, id string, w io.Writer) error {
 	return cmd.Run()
 }
 
-func (r *Repository) PushBranchOrigin(ctx context.Context, branch string) error {
+func (r *Repository) PushBranchToOrigin(ctx context.Context, branch string) error {
 	_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "get-url", "origin")
 	if err != nil {
 		return err


### PR DESCRIPTION
This request add a flag  -p in command checkout to allow to push branch created after checkout to your remote origin repository,
this is something that me and my teammates are doing  basically for two reasons.

- Some people  prefer to use a browser to review code (github, bitbucket),  and not use command "cu diff " in terminal.
- sometimes we want to push the branch to allow other people to review code