### PR TITLE
cu inspect

### DIFF
--- a/cmd/cu/inspect.go
+++ b/cmd/cu/inspect.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dagger/container-use/repository"
+	"github.com/spf13/cobra"
+)
+
+var inspectCmd = &cobra.Command{
+	Use:               "inspect <env>",
+	Short:             "Inspect an environment",
+	Long:              "This is an internal command used by the CLI to inspect an environment. It is not meant to be used by users.",
+	Args:              cobra.ExactArgs(1),
+	Hidden:            true,
+	ValidArgsFunction: suggestEnvironments,
+	RunE: func(app *cobra.Command, args []string) error {
+		ctx := app.Context()
+		repo, err := repository.Open(ctx, ".")
+		if err != nil {
+			return err
+		}
+
+		envInfo, err := repo.Info(ctx, args[0])
+		if err != nil {
+			return err
+		}
+
+		envInfo.State.Container = ""
+		out, err := json.MarshalIndent(envInfo, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(inspectCmd)
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -16,10 +16,10 @@ import (
 // EnvironmentInfo contains basic metadata about an environment
 // without requiring dagger operations
 type EnvironmentInfo struct {
-	Config *EnvironmentConfig
-	State  *State
+	Config *EnvironmentConfig `json:"config,omitempty"`
+	State  *State             `json:"state,omitempty"`
 
-	ID string
+	ID string `json:"id,omitempty"`
 }
 
 type Environment struct {


### PR DESCRIPTION
Flagged as hidden / internal for now.

Unsure about the output format, but for now, this is very useful to
debug. We can un-hide it once we're happy with the UX.
