### PR TITLE
Merge Experiments: ort-theirs and apply-3way

### DIFF
--- a/environment/integration/merge_test.go
+++ b/environment/integration/merge_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -146,5 +147,190 @@ func TestRepositoryMergeCompleted(t *testing.T) {
 		// Should have commits for both merges or their individual commits
 		assert.Contains(t, log, "Add initial file", "Log should contain initial commit")
 		assert.Contains(t, log, "Update file content", "Log should contain update commit")
+	})
+}
+
+// TestRepositoryMergeSquash tests squash merging an environment
+func TestRepositoryMergeSquash(t *testing.T) {
+	t.Parallel()
+	WithRepository(t, "repository-merge-squash", SetupEmptyRepo, func(t *testing.T, repo *repository.Repository, user *UserActions) {
+		ctx := context.Background()
+
+		// Create an environment and add some content
+		env := user.CreateEnvironment("Test Squash Merge", "Squash merge test with multiple files")
+		user.FileWrite(env.ID, "squash-test.txt", "content from environment", "Add squash test file")
+		user.FileWrite(env.ID, "config.json", `{"version": "1.0"}`, "Add config file")
+
+		// Get initial commit count
+		initialLog, err := repository.RunGitCommand(ctx, repo.SourcePath(), "rev-list", "--count", "HEAD")
+		require.NoError(t, err)
+		initialCommitCount := strings.TrimSpace(initialLog)
+
+		// Perform squash merge
+		var mergeOutput bytes.Buffer
+		err = repo.MergeSquash(ctx, env.ID, &mergeOutput)
+		require.NoError(t, err, "Squash merge should succeed: %s", mergeOutput.String())
+
+		// Verify the files were merged into the working directory
+		squashTestPath := filepath.Join(repo.SourcePath(), "squash-test.txt")
+		content, err := os.ReadFile(squashTestPath)
+		require.NoError(t, err)
+		assert.Equal(t, "content from environment", string(content))
+
+		configPath := filepath.Join(repo.SourcePath(), "config.json")
+		configContent, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, `{"version": "1.0"}`, string(configContent))
+
+		// Verify we have exactly one new commit
+		finalLog, err := repository.RunGitCommand(ctx, repo.SourcePath(), "rev-list", "--count", "HEAD")
+		require.NoError(t, err)
+		finalCommitCount := strings.TrimSpace(finalLog)
+
+		initialCount, err := strconv.Atoi(initialCommitCount)
+		require.NoError(t, err)
+		finalCount, err := strconv.Atoi(finalCommitCount)
+		require.NoError(t, err)
+		assert.Equal(t, initialCount+1, finalCount, "Should have exactly one new commit")
+
+		// Verify the commit message uses the environment title
+		commitMessage, err := repository.RunGitCommand(ctx, repo.SourcePath(), "log", "-1", "--pretty=format:%s")
+		require.NoError(t, err)
+		assert.Equal(t, "Test Squash Merge", commitMessage)
+	})
+}
+
+// TestRepositoryMergeSquashRepeated tests repeated squash merges with theirs strategy
+// This should allow updating the same file multiple times without conflicts
+func TestRepositoryMergeSquashRepeated(t *testing.T) {
+	t.Parallel()
+	WithRepository(t, "repository-merge-squash-repeated", SetupEmptyRepo, func(t *testing.T, repo *repository.Repository, user *UserActions) {
+		ctx := context.Background()
+
+		// Create an environment and add initial content
+		env := user.CreateEnvironment("Test Repeated Squash", "First squash commit")
+		user.FileWrite(env.ID, "repeated-squash.txt", "initial content", "Add initial file")
+
+		// First squash merge
+		var mergeOutput1 bytes.Buffer
+		err := repo.MergeSquash(ctx, env.ID, &mergeOutput1)
+		require.NoError(t, err, "First squash merge should succeed: %s", mergeOutput1.String())
+
+		// Verify first squash merge content
+		filePath := filepath.Join(repo.SourcePath(), "repeated-squash.txt")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "initial content", string(content))
+
+		// Update the same file in the environment - this should use theirs strategy
+		user.FileWrite(env.ID, "repeated-squash.txt", "updated content", "Update file content")
+		user.FileWrite(env.ID, "additional.txt", "new file content", "Add new file")
+
+		var mergeOutput2 bytes.Buffer
+		err = repo.MergeSquash(ctx, env.ID, &mergeOutput2)
+		require.NoError(t, err, "Second squash merge should succeed: %s", mergeOutput2.String())
+
+		// Verify second squash merge content - should have the updated content from environment
+		content, err = os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "updated content", string(content))
+
+		// Verify new file was added
+		additionalPath := filepath.Join(repo.SourcePath(), "additional.txt")
+		additionalContent, err := os.ReadFile(additionalPath)
+		require.NoError(t, err)
+		assert.Equal(t, "new file content", string(additionalContent))
+
+		// Verify we have clean squash commits in the log
+		log, err := repository.RunGitCommand(ctx, repo.SourcePath(), "log", "--oneline", "-5")
+		require.NoError(t, err)
+		// Both commits should have the same title since it's the same environment
+		commitCount := strings.Count(log, "Test Repeated Squash")
+		assert.Equal(t, 2, commitCount, "Should have two commits with environment title")
+	})
+}
+
+// TestRepositoryMergeSquashTheirsStrategy tests that theirs strategy is used when appropriate
+func TestRepositoryMergeSquashTheirsStrategy(t *testing.T) {
+	t.Parallel()
+	WithRepository(t, "repository-merge-squash-theirs", SetupEmptyRepo, func(t *testing.T, repo *repository.Repository, user *UserActions) {
+		ctx := context.Background()
+
+		// Create an environment and add initial content
+		env := user.CreateEnvironment("Test Theirs Strategy", "Testing theirs strategy")
+		user.FileWrite(env.ID, "conflict-file.txt", "environment version 1", "Add initial file")
+
+		// First squash merge
+		var mergeOutput1 bytes.Buffer
+		err := repo.MergeSquash(ctx, env.ID, &mergeOutput1)
+		require.NoError(t, err, "First squash merge should succeed: %s", mergeOutput1.String())
+
+		// Verify first squash merge content
+		filePath := filepath.Join(repo.SourcePath(), "conflict-file.txt")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "environment version 1", string(content))
+
+		// Now modify the same file in the environment to a different version
+		user.FileWrite(env.ID, "conflict-file.txt", "environment version 2", "Update file to version 2")
+
+		// Second squash merge - should use theirs strategy and favor environment version
+		var mergeOutput2 bytes.Buffer
+		err = repo.MergeSquash(ctx, env.ID, &mergeOutput2)
+		require.NoError(t, err, "Second squash merge should succeed with theirs strategy: %s", mergeOutput2.String())
+
+		// Verify the content is from the environment (theirs), not main branch (ours)
+		content, err = os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "environment version 2", string(content), "Should use environment version (updated content)")
+
+		// Verify we have clean squash commits in the log
+		log, err := repository.RunGitCommand(ctx, repo.SourcePath(), "log", "--oneline", "-5")
+		require.NoError(t, err)
+
+		// Should have two squash commits with environment title
+		commitCount := strings.Count(log, "Test Theirs Strategy")
+		assert.Equal(t, 2, commitCount, "Should have two squash commits with environment title")
+	})
+}
+
+// TestRepositoryMergeSquashConflictResolution tests that theirs strategy resolves conflicts correctly
+func TestRepositoryMergeSquashConflictResolution(t *testing.T) {
+	t.Parallel()
+	WithRepository(t, "repository-merge-squash-conflict", SetupEmptyRepo, func(t *testing.T, repo *repository.Repository, user *UserActions) {
+		ctx := context.Background()
+
+		// Create first environment and add initial content
+		env1 := user.CreateEnvironment("First Environment", "First squash merge")
+		user.FileWrite(env1.ID, "shared-file.txt", "content from first environment", "Add shared file")
+
+		// First squash merge
+		var mergeOutput1 bytes.Buffer
+		err := repo.MergeSquash(ctx, env1.ID, &mergeOutput1)
+		require.NoError(t, err, "First squash merge should succeed: %s", mergeOutput1.String())
+
+		// Create second environment and modify the same file
+		env2 := user.CreateEnvironment("Second Environment", "Second squash merge with conflict")
+		user.FileWrite(env2.ID, "shared-file.txt", "content from second environment", "Update shared file")
+
+		// Second squash merge - should use theirs strategy since all commits are squash merges
+		var mergeOutput2 bytes.Buffer
+		err = repo.MergeSquash(ctx, env2.ID, &mergeOutput2)
+		require.NoError(t, err, "Second squash merge should succeed with theirs strategy: %s", mergeOutput2.String())
+
+		// Verify the content is from the second environment (theirs)
+		filePath := filepath.Join(repo.SourcePath(), "shared-file.txt")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "content from second environment", string(content), "Should use second environment's content (theirs strategy)")
+
+		// Verify we have clean squash commits in the log
+		log, err := repository.RunGitCommand(ctx, repo.SourcePath(), "log", "--oneline", "-5")
+		require.NoError(t, err)
+
+		// Should have commits from both environments
+		assert.Contains(t, log, "Second Environment")
+		assert.Contains(t, log, "First Environment")
+		assert.Contains(t, log, "Initial commit")
 	})
 }


### PR DESCRIPTION
note: do not merge, this is very not done

this PR has 2 experiments in it, not fully implemented or tested, but it's intended to provide as a demonstration of a couple of other approaches to squash merging. both experiments use a squash-and-commit variant of squash merging rather than the native `git` one.

i think i really like the apply 3-way approach and you can see that one as [HEAD](https://github.com/dagger/container-use/commit/7fc7b2d4582bdc8d85e3a08ecfd8a03630d0201e). it combines the "meta" commit information idea that @tiborvass was throwing around (although I halfassed the impl, not using git internals yet) with a patch application technique that @eunomie pointed out [in discord](https://discord.com/channels/707636530424053791/1375159310757134386/1390477844810825808), and has nice conflict resolution properties. the idea is basically to generate a patch from a common ancestor, but with a slightly more expansive definition of "common ancestor" than native git would use: it treats previous squash-merge commits as common ancestors.

specifically the nice conflict resolution properties are that apply-3way allows repeated squash merges but will also surface conflicts if the user has created them on their current branch.

[the ort-theirs experiment](https://github.com/dagger/container-use/commit/5b0993565539d74403b88252984aabd8be4cf385) works pretty well provided that the user hasn't added commits to their LocalSource, but basically can't be applied in that case because it'll overwrite their changes on conflict.

if we want to go with this it'd need to:

- [ ] be wired up to the actual command
- [ ] stop putting the metadata in the commit message
- [ ] be tested for interop with non-squash cu merges
- [ ] be tested for user-rebased-their-localsource scenarios
- [ ] be tested for scenarios involving multiple environments