### PR TITLE
allow to pick an environment by default

### DIFF
--- a/cmd/cu/checkout.go
+++ b/cmd/cu/checkout.go
@@ -13,7 +13,7 @@ var checkoutCmd = &cobra.Command{
 	Long: `Bring an environment's work into your local git workspace.
 This creates a local branch from the environment's state so you can
 explore files in your IDE, make changes, or continue development.`,
-	Args:              cobra.ExactArgs(1),
+	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: suggestEnvironments,
 	Example: `# Switch to environment's branch locally
 cu checkout fancy-mallard
@@ -22,10 +22,14 @@ cu checkout fancy-mallard
 cu checkout fancy-mallard -b my-review-branch`,
 	RunE: func(app *cobra.Command, args []string) error {
 		ctx := app.Context()
-		envID := args[0]
 
 		// Ensure we're in a git repository
 		repo, err := repository.Open(ctx, ".")
+		if err != nil {
+			return err
+		}
+
+		envID, err := envOrDefault(ctx, firstOrEmpty(args), repo)
 		if err != nil {
 			return err
 		}

--- a/cmd/cu/diff.go
+++ b/cmd/cu/diff.go
@@ -12,7 +12,7 @@ var diffCmd = &cobra.Command{
 	Short: "Show what files an agent changed",
 	Long: `Display the code changes made by an agent in an environment.
 Shows a git diff between the environment's state and your current branch.`,
-	Args:              cobra.ExactArgs(1),
+	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: suggestEnvironments,
 	Example: `# See what changes the agent made
 cu diff fancy-mallard
@@ -28,7 +28,12 @@ cu diff backend-api`,
 			return err
 		}
 
-		return repo.Diff(ctx, args[0], os.Stdout)
+		envID, err := envOrDefault(ctx, firstOrEmpty(args), repo)
+		if err != nil {
+			return err
+		}
+
+		return repo.Diff(ctx, envID, os.Stdout)
 	},
 }
 

--- a/cmd/cu/env.go
+++ b/cmd/cu/env.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/container-use/repository"
+)
+
+func envOrDefault(ctx context.Context, arg string, repo *repository.Repository) (string, error) {
+	if arg != "" {
+		return arg, nil
+	}
+	if list, err := repo.List(ctx); err != nil {
+		return "", err
+	} else if len(list) == 0 {
+		return "", fmt.Errorf("no environment found")
+	} else if len(list) == 1 {
+		return list[0].ID, nil
+	} else {
+		return "", fmt.Errorf("please specify an environment")
+	}
+}
+
+func firstOrEmpty(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return ""
+}

--- a/cmd/cu/env.go
+++ b/cmd/cu/env.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dagger/container-use/repository"
+	"github.com/dagger/container-use/environment"
 )
 
-func envOrDefault(ctx context.Context, arg string, repo *repository.Repository) (string, error) {
+type repoLister interface {
+	List(ctx context.Context) ([]*environment.EnvironmentInfo, error)
+}
+
+func envOrDefault(ctx context.Context, arg string, repo repoLister) (string, error) {
 	if arg != "" {
 		return arg, nil
 	}

--- a/cmd/cu/env_test.go
+++ b/cmd/cu/env_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/container-use/environment"
+)
+
+func TestEnvironmentFromArgs(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name          string
+		arg           string
+		repo          repoLister
+		expected      string
+		expectedError bool
+	}{
+		{
+			name:          "arg defined and not environments",
+			arg:           "fancy-mallard",
+			repo:          &repo{},
+			expected:      "fancy-mallard",
+			expectedError: false,
+		},
+		{
+			name: "arg defined and environments",
+			arg:  "fancy-mallard",
+			repo: &repo{
+				list: []*environment.EnvironmentInfo{
+					{ID: "foo"},
+					{ID: "bar"},
+				},
+			},
+			expected:      "fancy-mallard",
+			expectedError: false,
+		},
+		{
+			name:          "no arg, no environment",
+			arg:           "",
+			repo:          &repo{},
+			expected:      "",
+			expectedError: true,
+		},
+		{
+			name: "no arg, one environment",
+			arg:  "",
+			repo: &repo{
+				list: []*environment.EnvironmentInfo{
+					{ID: "fancy-mallard"},
+				},
+			},
+			expected:      "fancy-mallard",
+			expectedError: false,
+		},
+		{
+			name: "no arg, more than one environment",
+			arg:  "",
+			repo: &repo{
+				list: []*environment.EnvironmentInfo{
+					{ID: "fancy-mallard"},
+					{ID: "bar"},
+				},
+			},
+			expected:      "",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := envOrDefault(ctx, tt.arg, tt.repo)
+			if (err != nil) != tt.expectedError {
+				t.Errorf("envOrDefault() error = %v, wantErr %v", err, tt.expectedError)
+				return
+			}
+			if env != tt.expected {
+				t.Errorf("envOrDefault() = %v, want %v", env, tt.expected)
+			}
+		})
+	}
+}
+
+type repo struct {
+	list []*environment.EnvironmentInfo
+}
+
+func (r *repo) List(_ context.Context) ([]*environment.EnvironmentInfo, error) {
+	return r.list, nil
+}

--- a/cmd/cu/inspect.go
+++ b/cmd/cu/inspect.go
@@ -22,7 +22,12 @@ var inspectCmd = &cobra.Command{
 			return err
 		}
 
-		envInfo, err := repo.Info(ctx, args[0])
+		envID, err := envOrDefault(ctx, firstOrEmpty(args), repo)
+		if err != nil {
+			return err
+		}
+
+		envInfo, err := repo.Info(ctx, envID)
 		if err != nil {
 			return err
 		}

--- a/cmd/cu/log.go
+++ b/cmd/cu/log.go
@@ -13,7 +13,7 @@ var logCmd = &cobra.Command{
 	Long: `Display the complete development history for an environment.
 Shows all commits made by the agent plus command execution notes.
 Use -p to include code patches in the output.`,
-	Args:              cobra.ExactArgs(1),
+	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: suggestEnvironments,
 	Example: `# See what agent did
 cu log fancy-mallard
@@ -29,9 +29,14 @@ cu log fancy-mallard -p`,
 			return err
 		}
 
+		envID, err := envOrDefault(ctx, firstOrEmpty(args), repo)
+		if err != nil {
+			return err
+		}
+
 		patch, _ := app.Flags().GetBool("patch")
 
-		return repo.Log(ctx, args[0], patch, os.Stdout)
+		return repo.Log(ctx, envID, patch, os.Stdout)
 	},
 }
 

--- a/cmd/cu/merge.go
+++ b/cmd/cu/merge.go
@@ -18,7 +18,7 @@ var mergeCmd = &cobra.Command{
 	Long: `Merge an environment's changes into your current git branch.
 This makes the agent's work permanent in your repository.
 Your working directory will be automatically stashed and restored.`,
-	Args:              cobra.ExactArgs(1),
+	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: suggestEnvironments,
 	Example: `# Accept agent's work into current branch
 cu merge backend-api
@@ -35,7 +35,10 @@ cu merge --delete backend-api`,
 			return err
 		}
 
-		env := args[0]
+		env, err := envOrDefault(ctx, firstOrEmpty(args), repo)
+		if err != nil {
+			return err
+		}
 
 		if err := repo.Merge(ctx, env, os.Stdout); err != nil {
 			return fmt.Errorf("failed to merge environment: %w", err)

--- a/cmd/cu/terminal.go
+++ b/cmd/cu/terminal.go
@@ -31,6 +31,11 @@ cu terminal backend-api`,
 			return err
 		}
 
+		envID, err := envOrDefault(ctx, firstOrEmpty(args), repo)
+		if err != nil {
+			return err
+		}
+
 		// FIXME(aluzzardi): This is a hack to make sure we're wrapped in `dagger run` since `Terminal()` only works with the CLI.
 		// If not, it will auto-wrap this command in a `dagger run`.
 		if _, ok := os.LookupEnv("DAGGER_SESSION_TOKEN"); !ok {
@@ -52,7 +57,7 @@ cu terminal backend-api`,
 			return fmt.Errorf("failed to connect to dagger: %w", err)
 		}
 		defer dag.Close()
-		env, err := repo.Get(ctx, dag, args[0])
+		env, err := repo.Get(ctx, dag, envID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In case there's one single environment available and none is set as an argument, pick the only environment.

So that it's possible to run `cu merge`, `cu diff`, `cu terminal` without arguments if there's a single environment.