### PR TITLE
repository: handle detached HEAD

### DIFF
--- a/repository/git.go
+++ b/repository/git.go
@@ -296,6 +296,9 @@ func (r *Repository) mergeBase(ctx context.Context, env *environment.Environment
 		return "", err
 	}
 	currentBranch = strings.TrimSpace(currentBranch)
+	if currentBranch == "" {
+		currentBranch = "HEAD"
+	}
 	envGitRef := fmt.Sprintf("%s/%s", containerUseRemote, env.ID)
 	mergeBase, err := RunGitCommand(ctx, r.userRepoPath, "merge-base", currentBranch, envGitRef)
 	if err != nil {


### PR DESCRIPTION
Fixes a bug when running `cu diff <env>` in detached HEAD mode.