### PR TITLE
Initial MCP Roots support

### DIFF
--- a/mcpserver/roots.go
+++ b/mcpserver/roots.go
@@ -2,7 +2,6 @@ package mcpserver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -46,35 +45,38 @@ func sendRootsListRequest(ctx context.Context, session server.ClientSession) {
 
 // updateClientRoots parses roots from notification params and updates the global clientRoots
 func updateClientRoots(notification mcp.JSONRPCNotification) int {
-	if notification.Params.AdditionalFields != nil {
-		if rootsData, ok := notification.Params.AdditionalFields["roots"].([]any); ok {
-			newRoots := make([]mcp.Root, 0, len(rootsData))
-			for _, rootData := range rootsData {
-				if rootMap, ok := rootData.(map[string]any); ok {
-					root := mcp.Root{}
-					if uri, ok := rootMap["uri"].(string); ok {
-						root.URI = uri
-					}
-					if name, ok := rootMap["name"].(string); ok {
-						root.Name = name
-					}
-					newRoots = append(newRoots, root)
-				}
+	if notification.Params.AdditionalFields == nil {
+		return 0
+	}
+	rootsData, ok := notification.Params.AdditionalFields["roots"].([]any)
+	if !ok {
+		return 0
+	}
+
+	newRoots := make([]mcp.Root, 0, len(rootsData))
+	for _, rootData := range rootsData {
+		if rootMap, ok := rootData.(map[string]any); ok {
+			root := mcp.Root{}
+			if uri, ok := rootMap["uri"].(string); ok {
+				root.URI = uri
 			}
-
-			clientRootsMu.Lock()
-			clientRoots = newRoots
-			clientRootsMu.Unlock()
-
-			return len(newRoots)
+			if name, ok := rootMap["name"].(string); ok {
+				root.Name = name
+			}
+			newRoots = append(newRoots, root)
 		}
 	}
-	return 0
+
+	clientRootsMu.Lock()
+	clientRoots = newRoots
+	clientRootsMu.Unlock()
+
+	return len(newRoots)
 }
 
 // repoOpenErrorMessage provides helpful error messages when repository opening fails
 func repoOpenErrorMessage(source string, originalErr error) error {
-	baseMsg := fmt.Sprintf("failed to open repository '%s': %v", source, originalErr)
+	baseMsg := fmt.Sprintf("failed to open repository '%s'", source)
 
 	// If we have client roots, suggest them
 	clientRootsMu.RLock()
@@ -91,10 +93,10 @@ func repoOpenErrorMessage(source string, originalErr error) error {
 				baseMsg += fmt.Sprintf("\n  - %s", uri)
 			}
 		}
-		return errors.New(baseMsg)
+		return fmt.Errorf("%s: %w", baseMsg, originalErr)
 	}
 
 	// Fallback: suggest common patterns
 	baseMsg += "\n\nTry using:\n  - '.' for current directory\n  - An absolute path to your git repository"
-	return errors.New(baseMsg)
+	return fmt.Errorf("%s: %w", baseMsg, originalErr)
 }

--- a/mcpserver/roots.go
+++ b/mcpserver/roots.go
@@ -1,0 +1,100 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// clientRoots holds the roots provided by the client
+// this assumes a single client, which may go out the window when we add support for streaming http.
+var (
+	clientRoots   []mcp.Root
+	clientRootsMu sync.RWMutex
+)
+
+// sendRootsListRequest sends a roots/list request to the client
+func sendRootsListRequest(ctx context.Context, session server.ClientSession) {
+	if session == nil {
+		return
+	}
+
+	// Send roots/list request as a notification
+	// Note: In a proper implementation, this would be a request-response
+	// but for now we'll send as notification and handle response separately
+	notification := mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "roots/list",
+			Params: mcp.NotificationParams{},
+		},
+	}
+
+	select {
+	case session.NotificationChannel() <- notification:
+		slog.Info("Requested roots/list from client")
+	case <-ctx.Done():
+		return
+	}
+}
+
+// updateClientRoots parses roots from notification params and updates the global clientRoots
+func updateClientRoots(notification mcp.JSONRPCNotification) int {
+	if notification.Params.AdditionalFields != nil {
+		if rootsData, ok := notification.Params.AdditionalFields["roots"].([]any); ok {
+			newRoots := make([]mcp.Root, 0, len(rootsData))
+			for _, rootData := range rootsData {
+				if rootMap, ok := rootData.(map[string]any); ok {
+					root := mcp.Root{}
+					if uri, ok := rootMap["uri"].(string); ok {
+						root.URI = uri
+					}
+					if name, ok := rootMap["name"].(string); ok {
+						root.Name = name
+					}
+					newRoots = append(newRoots, root)
+				}
+			}
+
+			clientRootsMu.Lock()
+			clientRoots = newRoots
+			clientRootsMu.Unlock()
+
+			return len(newRoots)
+		}
+	}
+	return 0
+}
+
+// repoOpenErrorMessage provides helpful error messages when repository opening fails
+func repoOpenErrorMessage(source string, originalErr error) error {
+	baseMsg := fmt.Sprintf("failed to open repository '%s': %v", source, originalErr)
+
+	// If we have client roots, suggest them
+	clientRootsMu.RLock()
+	defer clientRootsMu.RUnlock()
+
+	if len(clientRoots) > 0 {
+		baseMsg += "\n\nAvailable roots from client:"
+		for _, root := range clientRoots {
+			uri := root.URI
+			uri = strings.TrimPrefix(uri, "file://")
+			if root.Name != "" {
+				baseMsg += fmt.Sprintf("\n  - %s (%s)", uri, root.Name)
+			} else {
+				baseMsg += fmt.Sprintf("\n  - %s", uri)
+			}
+		}
+		return errors.New(baseMsg)
+	}
+
+	// Fallback: suggest common patterns
+	baseMsg += "\n\nTry using:\n  - '.' for current directory\n  - An absolute path to your git repository"
+	return errors.New(baseMsg)
+}


### PR DESCRIPTION
impl is as minimal as possible. tested via `echo {json} | timeout 5 cu stdio`, still need to test with actual vscode.

currently only used to facilitate better error messages on repo.Open, but with dynamic tools we can also use the roots to provide better tool descriptions.