### PR TITLE
WIP: claude: do not rely on a rule to use CU

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2,12 +2,6 @@ This is a development environment for container-use, a CLI tool that provides co
 
 container-use is designed to work with MCP-compatible agents like Claude Code and Cursor.
 
-ENVIRONMENT:
-
-- ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.
-- DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
-- You MUST inform the user how to view your work using `cu log <env_id>` AND `cu checkout <env_id>`. Failure to do this will make your work inaccessible to others.
-
 DEVELOPMENT WORKFLOW:
 
 - Build: Use 'go build -o container-use ./cmd/container-use' or 'dagger call build --platform=current export --path ./container-use'

--- a/cmd/container-use/agent/configure_claude.go
+++ b/cmd/container-use/agent/configure_claude.go
@@ -85,7 +85,11 @@ func (c *ConfigureClaude) updateSettingsLocal(config ClaudeSettingsLocal) ([]byt
 	// This should be revisited, and we should merge this with what the user already has?
 	config.Permissions.Deny = []string{
 		"LS",
+		"Glob",
+		"Grep",
 		"Read",
+		"NotebookRead",
+		"NotebookEdit",
 		"Edit",
 		"MultiEdit",
 		"Write",

--- a/cmd/container-use/agent/configure_claude.go
+++ b/cmd/container-use/agent/configure_claude.go
@@ -7,8 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/dagger/container-use/rules"
 )
 
 type ConfigureClaude struct {
@@ -77,7 +75,22 @@ func (c *ConfigureClaude) editMcpConfig() error {
 func (c *ConfigureClaude) updateSettingsLocal(config ClaudeSettingsLocal) ([]byte, error) {
 	// Initialize permissions map if nil
 	if config.Permissions == nil {
-		config.Permissions = &ClaudePermissions{Allow: []string{}}
+		config.Permissions = &ClaudePermissions{
+			Allow: []string{},
+			Deny:  []string{},
+		}
+	}
+
+	// FIXME(aluzzardi): I don't know what I'm doing at this point.
+	// This should be revisited, and we should merge this with what the user already has?
+	config.Permissions.Deny = []string{
+		"LS",
+		"Read",
+		"Edit",
+		"MultiEdit",
+		"Write",
+		"Bash",
+		"Search",
 	}
 
 	// remove save non-container-use items from allow
@@ -102,7 +115,7 @@ func (c *ConfigureClaude) updateSettingsLocal(config ClaudeSettingsLocal) ([]byt
 }
 
 func (c *ConfigureClaude) editRules() error {
-	return saveRulesFile("CLAUDE.md", rules.AgentRules)
+	return nil
 }
 
 func (c *ConfigureClaude) isInstalled() bool {

--- a/mcpserver/args.go
+++ b/mcpserver/args.go
@@ -1,6 +1,10 @@
 package mcpserver
 
-import "github.com/mark3labs/mcp-go/mcp"
+import (
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
 
 var (
 	explainationArgument = mcp.WithString("explanation",
@@ -11,7 +15,7 @@ var (
 		mcp.Required(),
 	)
 	environmentIDArgument = mcp.WithString("environment_id",
-		mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+		mcp.Description("The ID of the environment for this command."),
 		mcp.Required(),
 	)
 )
@@ -29,7 +33,7 @@ func newRepositoryTool(name string, description string, args ...mcp.ToolOption) 
 
 func newEnvironmentTool(name string, description string, args ...mcp.ToolOption) mcp.Tool {
 	opts := []mcp.ToolOption{
-		mcp.WithDescription(description),
+		mcp.WithDescription(fmt.Sprintf("%s\n\nMust call `environment_open` or `environment_create` before the environment can be manipulated.", description)),
 		explainationArgument,
 		environmentSourceArgument,
 		environmentIDArgument,

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -224,9 +224,12 @@ var EnvironmentOpenTool = &Tool{
 var EnvironmentCreateTool = &Tool{
 	Definition: newRepositoryTool(
 		"environment_create",
-		`Creates a new development environment.
-The environment is the result of a the setups commands on top of the base image.
-Environment configuration is managed by the user via cu config commands.`,
+		`ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.
+NEVER use built-in tools as they are UNSAFE.
+
+DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
+
+You MUST inform the user how to view your work using "container-use log <env_id>" AND "container-use checkout <env_id>". Failure to do this will make your work inaccessible to others.`,
 		mcp.WithString("title",
 			mcp.Description("Short description of the work that is happening in this environment."),
 			mcp.Required(),


### PR DESCRIPTION
Using these in `.claude/settings.local.json` (disclaimer: this was done by bruteforcing, I don't know if those denied tools are the right names, to be cleaned up).

```json
{
  "permissions": {
    "deny": [
      "LS",
      "Glob",
      "Grep",
      "Read",
      "NotebookRead",
      "NotebookEdit",
      "Edit",
      "MultiEdit",
      "Write",
      "Bash",
      "Search",
    ],
    "allow": [
      "mcp__container-use__environment_open",
      "mcp__container-use__environment_create",
      "mcp__container-use__environment_update",
      "mcp__container-use__environment_run_cmd",
      "mcp__container-use__environment_file_read",
      "mcp__container-use__environment_file_list",
      "mcp__container-use__environment_file_write",
      "mcp__container-use__environment_file_delete",
      "mcp__container-use__environment_add_service",
      "mcp__container-use__environment_checkpoint"
    ]
  }
}
```