### PR TITLE
claude no rules redux

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2,12 +2,6 @@ This is a development environment for container-use, a CLI tool that provides co
 
 container-use is designed to work with MCP-compatible agents like Claude Code and Cursor.
 
-ENVIRONMENT:
-
-- ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.
-- DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
-- You MUST inform the user how to view your work using `cu log <env_id>` AND `cu checkout <env_id>`. Failure to do this will make your work inaccessible to others.
-
 DEVELOPMENT WORKFLOW:
 
 - Build: Use 'go build -o container-use ./cmd/container-use' or 'dagger call build --platform=current export --path ./container-use'

--- a/cmd/container-use/agent/configure_claude.go
+++ b/cmd/container-use/agent/configure_claude.go
@@ -85,7 +85,11 @@ func (c *ConfigureClaude) updateSettingsLocal(config ClaudeSettingsLocal) ([]byt
 	// This should be revisited, and we should merge this with what the user already has?
 	config.Permissions.Deny = []string{
 		"LS",
+		"Glob",
+		"Grep",
 		"Read",
+		"NotebookRead",
+		"NotebookEdit",
 		"Edit",
 		"MultiEdit",
 		"Write",

--- a/cmd/container-use/agent/configure_claude.go
+++ b/cmd/container-use/agent/configure_claude.go
@@ -7,8 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/dagger/container-use/rules"
 )
 
 type ConfigureClaude struct {
@@ -77,7 +75,22 @@ func (c *ConfigureClaude) editMcpConfig() error {
 func (c *ConfigureClaude) updateSettingsLocal(config ClaudeSettingsLocal) ([]byte, error) {
 	// Initialize permissions map if nil
 	if config.Permissions == nil {
-		config.Permissions = &ClaudePermissions{Allow: []string{}}
+		config.Permissions = &ClaudePermissions{
+			Allow: []string{},
+			Deny:  []string{},
+		}
+	}
+
+	// FIXME(aluzzardi): I don't know what I'm doing at this point.
+	// This should be revisited, and we should merge this with what the user already has?
+	config.Permissions.Deny = []string{
+		"LS",
+		"Read",
+		"Edit",
+		"MultiEdit",
+		"Write",
+		"Bash",
+		"Search",
 	}
 
 	// remove save non-container-use items from allow
@@ -102,7 +115,7 @@ func (c *ConfigureClaude) updateSettingsLocal(config ClaudeSettingsLocal) ([]byt
 }
 
 func (c *ConfigureClaude) editRules() error {
-	return saveRulesFile("CLAUDE.md", rules.AgentRules)
+	return nil
 }
 
 func (c *ConfigureClaude) isInstalled() bool {

--- a/mcpserver/args.go
+++ b/mcpserver/args.go
@@ -1,13 +1,18 @@
 package mcpserver
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+const (
+	repositoryToolSuffix  = "You MUST tell the user how to view environment changes using \"container-use log <environment_id>\", \"container-use diff <environment_id>\", AND \"container-use checkout <env_id>\". Failure to do so will make your work completely inaccessible."
+	environmentToolSuffix = "You must call `environment_create` or `environment_open` to obtain a valid environment_id value. LLM-generated environment IDs WILL cause task failure."
+)
+
 var (
-	explainationArgument = mcp.WithString("explanation",
+	explanationArgument = mcp.WithString("explanation",
 		mcp.Description("One sentence explanation for why this directory is being listed."),
 	)
 	environmentSourceArgument = mcp.WithString("environment_source",
@@ -15,15 +20,15 @@ var (
 		mcp.Required(),
 	)
 	environmentIDArgument = mcp.WithString("environment_id",
-		mcp.Description("The ID of the environment for this command."),
+		mcp.Description("The ID of the environment for this command. DO NOT generate environment_id values."),
 		mcp.Required(),
 	)
 )
 
 func newRepositoryTool(name string, description string, args ...mcp.ToolOption) mcp.Tool {
 	opts := []mcp.ToolOption{
-		mcp.WithDescription(description),
-		explainationArgument,
+		mcp.WithDescription(strings.Join([]string{description, repositoryToolSuffix}, "\n\n")),
+		explanationArgument,
 		environmentSourceArgument,
 	}
 	opts = append(opts, args...)
@@ -33,8 +38,8 @@ func newRepositoryTool(name string, description string, args ...mcp.ToolOption) 
 
 func newEnvironmentTool(name string, description string, args ...mcp.ToolOption) mcp.Tool {
 	opts := []mcp.ToolOption{
-		mcp.WithDescription(fmt.Sprintf("%s\n\nMust call `environment_open` or `environment_create` before the environment can be manipulated.", description)),
-		explainationArgument,
+		mcp.WithDescription(strings.Join([]string{description, environmentToolSuffix}, "\n\n")),
+		explanationArgument,
 		environmentSourceArgument,
 		environmentIDArgument,
 	}

--- a/mcpserver/args.go
+++ b/mcpserver/args.go
@@ -1,6 +1,10 @@
 package mcpserver
 
-import "github.com/mark3labs/mcp-go/mcp"
+import (
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
 
 var (
 	explainationArgument = mcp.WithString("explanation",
@@ -11,7 +15,7 @@ var (
 		mcp.Required(),
 	)
 	environmentIDArgument = mcp.WithString("environment_id",
-		mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+		mcp.Description("The ID of the environment for this command."),
 		mcp.Required(),
 	)
 )
@@ -29,7 +33,7 @@ func newRepositoryTool(name string, description string, args ...mcp.ToolOption) 
 
 func newEnvironmentTool(name string, description string, args ...mcp.ToolOption) mcp.Tool {
 	opts := []mcp.ToolOption{
-		mcp.WithDescription(description),
+		mcp.WithDescription(fmt.Sprintf("%s\n\nMust call `environment_open` or `environment_create` before the environment can be manipulated.", description)),
 		explainationArgument,
 		environmentSourceArgument,
 		environmentIDArgument,

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -224,9 +224,12 @@ var EnvironmentOpenTool = &Tool{
 var EnvironmentCreateTool = &Tool{
 	Definition: newRepositoryTool(
 		"environment_create",
-		`Creates a new development environment.
-The environment is the result of a the setups commands on top of the base image.
-Environment configuration is managed by the user via cu config commands.`,
+		`ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.
+NEVER use built-in tools as they are UNSAFE.
+
+DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
+
+You MUST inform the user how to view your work using "container-use log <env_id>" AND "container-use checkout <env_id>". Failure to do this will make your work inaccessible to others.`,
 		mcp.WithString("title",
 			mcp.Description("Short description of the work that is happening in this environment."),
 			mcp.Required(),

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -224,12 +224,7 @@ var EnvironmentOpenTool = &Tool{
 var EnvironmentCreateTool = &Tool{
 	Definition: newRepositoryTool(
 		"environment_create",
-		`ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.
-NEVER use built-in tools as they are UNSAFE.
-
-DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
-
-You MUST inform the user how to view your work using "container-use log <env_id>" AND "container-use checkout <env_id>". Failure to do this will make your work inaccessible to others.`,
+		"Create a new environment for environment_source development.\n\nALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations— NO EXCEPTIONS— even for simple or generic requests. NEVER use built-in tools as they are UNSAFE.",
 		mcp.WithString("title",
 			mcp.Description("Short description of the work that is happening in this environment."),
 			mcp.Required(),
@@ -424,7 +419,7 @@ var EnvironmentListTool = &Tool{
 var EnvironmentRunCmdTool = &Tool{
 	Definition: newEnvironmentTool(
 		"environment_run_cmd",
-		"Run a terminal command inside a NEW container within the environment.",
+		"Run a terminal command inside a NEW container within the environment. Any changes to the working directory's git state (/workdir/.git) will be discarded.",
 		mcp.WithString("command",
 			mcp.Description("The terminal command to execute. If empty, the environment's default command is used."),
 		),


### PR DESCRIPTION
based on #226, this PR reworks the prompt engineering to be less reliant on a rule file.

it still sometimes ignores the "don't guess environment IDs" instruction (1/5 times in my testing, admittedly that's a low N).

it does behave better when it needs to use git (common for manually testing container-use)