### PR TITLE
bidirectional syncing to/from user worktree

### DIFF
--- a/cmd/container-use/apply.go
+++ b/cmd/container-use/apply.go
@@ -43,7 +43,7 @@ git commit -m "Add backend API implementation"`,
 
 		env := args[0]
 
-		if err := repo.Apply(ctx, env, os.Stdout); err != nil {
+		if err := repo.Apply(ctx, env, os.Stdout, false); err != nil {
 			return fmt.Errorf("failed to apply environment: %w", err)
 		}
 

--- a/cmd/container-use/list.go
+++ b/cmd/container-use/list.go
@@ -33,11 +33,11 @@ Use -q for environment IDs only, useful for scripting.`,
 		}
 
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "ID\tTITLE\tCREATED\tUPDATED")
+		fmt.Fprintln(tw, "ID\tBRANCH\tTITLE\tCREATED\tUPDATED\tEPHEMERAL")
 
 		defer tw.Flush()
 		for _, envInfo := range envInfos {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", envInfo.ID, truncate(app, envInfo.State.Title, 40), humanize.Time(envInfo.State.CreatedAt), humanize.Time(envInfo.State.UpdatedAt))
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%v\n", envInfo.ID, envInfo.State.TrackingBranch, truncate(app, envInfo.State.Title, 40), humanize.Time(envInfo.State.CreatedAt), humanize.Time(envInfo.State.UpdatedAt), envInfo.State.Ephemeral)
 		}
 		return nil
 	},

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -31,15 +31,17 @@ type Environment struct {
 	mu sync.RWMutex
 }
 
-func New(ctx context.Context, dag *dagger.Client, id, title string, config *EnvironmentConfig, initialSourceDir *dagger.Directory) (*Environment, error) {
+func New(ctx context.Context, dag *dagger.Client, id, branch, title string, ephemeral bool, config *EnvironmentConfig, initialSourceDir *dagger.Directory) (*Environment, error) {
 	env := &Environment{
 		EnvironmentInfo: &EnvironmentInfo{
 			ID: id,
 			State: &State{
-				Config:    config,
-				Title:     title,
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
+				Config:         config,
+				Title:          title,
+				TrackingBranch: branch,
+				Ephemeral:      ephemeral,
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
 			},
 		},
 		dag: dag,

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -114,14 +114,18 @@ func (env *Environment) FileSearchReplace(ctx context.Context, explanation, targ
 
 	// Apply the changes using `patch` so we don't have to spit out the entire
 	// contents
-	err = env.apply(ctx, env.container().
+	return env.ApplyPatch(ctx, godiffpatch.GeneratePatch(targetFile, contents, newContents))
+}
+
+func (env *Environment) ApplyPatch(ctx context.Context, patch string) error {
+	err := env.apply(ctx, env.container().
 		WithExec([]string{"patch", "-p1"}, dagger.ContainerWithExecOpts{
-			Stdin: godiffpatch.GeneratePatch(targetFile, contents, newContents),
+			Stdin: patch,
 		}))
 	if err != nil {
 		return fmt.Errorf("failed applying file edit, skipping git propagation: %w", err)
 	}
-	env.Notes.Add("Edit %s", targetFile)
+	env.Notes.Add("Apply patch")
 	return nil
 }
 

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -117,10 +117,9 @@ func (env *Environment) FileSearchReplace(ctx context.Context, explanation, targ
 }
 
 func (env *Environment) ApplyPatch(ctx context.Context, patch string) error {
-	err := env.apply(ctx, env.container().
-		WithExec([]string{"patch", "-p1"}, dagger.ContainerWithExecOpts{
-			Stdin: patch,
-		}))
+	ctr := env.container()
+	err := env.apply(ctx, ctr.
+		WithDirectory(".", ctr.Directory(".").WithPatch(patch)))
 	if err != nil {
 		return fmt.Errorf("failed applying file edit, skipping git propagation: %w", err)
 	}

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"dagger.io/dagger"
 	godiffpatch "github.com/sourcegraph/go-diff-patch"
 )
 

--- a/environment/filesystem.go
+++ b/environment/filesystem.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 )
@@ -45,6 +46,78 @@ func (env *Environment) FileWrite(ctx context.Context, explanation, targetFile, 
 	return nil
 }
 
+func (env *Environment) FileSearchReplace(ctx context.Context, explanation, targetFile, search, replace, matchID string) error {
+	contents, err := env.container().File(targetFile).Contents(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Find all matches of the search text
+	matches := []int{}
+	searchIndex := 0
+	for {
+		index := strings.Index(contents[searchIndex:], search)
+		if index == -1 {
+			break
+		}
+		actualIndex := searchIndex + index
+		matches = append(matches, actualIndex)
+		searchIndex = actualIndex + 1
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("search text not found in file %s", targetFile)
+	}
+
+	// If there are multiple matches and no matchID is provided, return an error with all matches
+	if len(matches) > 1 && matchID == "" {
+		var matchDescriptions []string
+		for i, matchIndex := range matches {
+			// Generate a unique ID for each match
+			id := generateMatchID(targetFile, search, replace, i)
+
+			// Get context around the match (3 lines before and after)
+			context := getMatchContext(contents, matchIndex, len(search))
+
+			matchDescriptions = append(matchDescriptions, fmt.Sprintf("Match %d (ID: %s):\n%s", i+1, id, context))
+		}
+
+		return fmt.Errorf("multiple matches found for search text in %s. Please specify which_match parameter with one of the following IDs:\n\n%s",
+			targetFile, strings.Join(matchDescriptions, "\n\n"))
+	}
+
+	// Determine which match to replace
+	var targetMatchIndex int
+	if len(matches) == 1 {
+		targetMatchIndex = matches[0]
+	} else {
+		// Find the match with the specified ID
+		found := false
+		for i, matchIndex := range matches {
+			id := generateMatchID(targetFile, search, replace, i)
+			if id == matchID {
+				targetMatchIndex = matchIndex
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("match ID %s not found", matchID)
+		}
+	}
+
+	// Replace the specific match
+	newContents := contents[:targetMatchIndex] + replace + contents[targetMatchIndex+len(search):]
+
+	// Apply the changes
+	err = env.apply(ctx, env.container().WithNewFile(targetFile, newContents))
+	if err != nil {
+		return fmt.Errorf("failed applying file edit, skipping git propagation: %w", err)
+	}
+	env.Notes.Add("Edit %s", targetFile)
+	return nil
+}
+
 func (env *Environment) FileDelete(ctx context.Context, explanation, targetFile string) error {
 	err := env.apply(ctx, env.container().WithoutFile(targetFile))
 	if err != nil {
@@ -64,4 +137,42 @@ func (env *Environment) FileList(ctx context.Context, path string) (string, erro
 		fmt.Fprintf(out, "%s\n", entry)
 	}
 	return out.String(), nil
+}
+
+// generateMatchID creates a unique ID for a match based on file, search, replace, and index
+func generateMatchID(targetFile, search, replace string, index int) string {
+	data := fmt.Sprintf("%s:%s:%s:%d", targetFile, search, replace, index)
+	hash := sha256.Sum256([]byte(data))
+	return fmt.Sprintf("%x", hash)[:8] // Use first 8 characters of hash
+}
+
+// getMatchContext returns the context around a match (3 lines before and after)
+func getMatchContext(contents string, matchIndex, matchLength int) string {
+	lines := strings.Split(contents, "\n")
+
+	// Find which line contains the match
+	currentPos := 0
+	matchLine := 0
+	for i, line := range lines {
+		if currentPos+len(line) >= matchIndex {
+			matchLine = i
+			break
+		}
+		currentPos += len(line) + 1 // +1 for newline
+	}
+
+	// Get context lines (3 before, match line, 3 after)
+	start := max(0, matchLine-3)
+	end := min(len(lines), matchLine+4)
+
+	contextLines := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		prefix := "  "
+		if i == matchLine {
+			prefix = "> " // Mark the line containing the match
+		}
+		contextLines = append(contextLines, fmt.Sprintf("%s%s", prefix, lines[i]))
+	}
+
+	return strings.Join(contextLines, "\n")
 }

--- a/environment/integration/merge_test.go
+++ b/environment/integration/merge_test.go
@@ -79,7 +79,7 @@ func TestRepositoryApply(t *testing.T) {
 
 		// Apply the environment (squash merge)
 		var applyOutput bytes.Buffer
-		err = repo.Apply(ctx, env.ID, &applyOutput)
+		err = repo.Apply(ctx, env.ID, &applyOutput, true)
 		require.NoError(t, err, "Apply should succeed: %s", applyOutput.String())
 
 		// Verify we're still on the initial branch
@@ -146,7 +146,7 @@ func TestRepositoryApplyNonExistent(t *testing.T) {
 
 		// Try to apply non-existent environment
 		var applyOutput bytes.Buffer
-		err := repo.Apply(ctx, "non-existent-env", &applyOutput)
+		err := repo.Apply(ctx, "non-existent-env", &applyOutput, true)
 		assert.Error(t, err, "Applying non-existent environment should fail")
 		assert.Contains(t, err.Error(), "not found")
 	})
@@ -203,7 +203,7 @@ func TestRepositoryApplyWithConflicts(t *testing.T) {
 
 		// Try to apply - this should fail due to conflict
 		var applyOutput bytes.Buffer
-		err = repo.Apply(ctx, env.ID, &applyOutput)
+		err = repo.Apply(ctx, env.ID, &applyOutput, true)
 
 		// The apply should fail due to conflict
 		assert.Error(t, err, "Apply should fail due to conflict")

--- a/environment/state.go
+++ b/environment/state.go
@@ -14,6 +14,7 @@ type State struct {
 	Container      string             `json:"container,omitempty"`
 	Title          string             `json:"title,omitempty"`
 	TrackingBranch string             `json:"tracking_branch,omitempty"`
+	Ephemeral      bool               `json:"ephemeral,omitempty"`
 }
 
 func (s *State) Marshal() ([]byte, error) {

--- a/environment/state.go
+++ b/environment/state.go
@@ -10,9 +10,10 @@ type State struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 
-	Config    *EnvironmentConfig `json:"config,omitempty"`
-	Container string             `json:"container,omitempty"`
-	Title     string             `json:"title,omitempty"`
+	Config         *EnvironmentConfig `json:"config,omitempty"`
+	Container      string             `json:"container,omitempty"`
+	Title          string             `json:"title,omitempty"`
+	TrackingBranch string             `json:"tracking_branch,omitempty"`
 }
 
 func (s *State) Marshal() ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 toolchain go1.24.4
 
 require (
-	dagger.io/dagger v0.18.12
+	dagger.io/dagger v0.18.14
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/fang v0.3.0
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -14,6 +14,7 @@ require (
 	github.com/mark3labs/mcp-go v0.29.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/sourcegraph/go-diff-patch v0.0.0-20240223163233-798fd1e94a8e
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tiborvass/go-watch v0.0.0-20250607214558-08999a83bf8b
@@ -56,7 +57,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
-	github.com/sourcegraph/go-diff-patch v0.0.0-20240223163233-798fd1e94a8e // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.28 // indirect

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
+	github.com/sourcegraph/go-diff-patch v0.0.0-20240223163233-798fd1e94a8e // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.28 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sosodev/duration v1.3.1 h1:qtHBDMQ6lvMQsL15g4aopM4HEfOaYuhWBw3NPTtlqq4=
 github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
+github.com/sourcegraph/go-diff-patch v0.0.0-20240223163233-798fd1e94a8e h1:H+jDTUeF+SVd4ApwnSFoew8ZwGNRfgb9EsZc7LcocAg=
+github.com/sourcegraph/go-diff-patch v0.0.0-20240223163233-798fd1e94a8e/go.mod h1:VsUklG6OQo7Ctunu0gS3AtEOCEc2kMB6r5rKzxAes58=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-dagger.io/dagger v0.18.11 h1:6lSfemlbGM2HmdOjhgevrX2+orMDGKU/xTaBMZ+otyY=
-dagger.io/dagger v0.18.11/go.mod h1:azlZ24m2br95t0jQHUBpL5SiafeqtVDLl1Itlq6GO+4=
-dagger.io/dagger v0.18.12 h1:s7v8aHlzDUogZ/jW92lHC+gljCNRML+0mosfh13R4vs=
-dagger.io/dagger v0.18.12/go.mod h1:azlZ24m2br95t0jQHUBpL5SiafeqtVDLl1Itlq6GO+4=
+dagger.io/dagger v0.18.14 h1:7+VFqNJffm6Qa8ckNRMfsM64sI5dXbRnZswCQ1jnDF0=
+dagger.io/dagger v0.18.14/go.mod h1:azlZ24m2br95t0jQHUBpL5SiafeqtVDLl1Itlq6GO+4=
 github.com/99designs/gqlgen v0.17.75 h1:GwHJsptXWLHeY7JO8b7YueUI4w9Pom6wJTICosDtQuI=
 github.com/99designs/gqlgen v0.17.75/go.mod h1:p7gbTpdnHyl70hmSpM8XG8GiKwmCv+T5zkdY8U8bLog=
 github.com/Khan/genqlient v0.8.1 h1:wtOCc8N9rNynRLXN3k3CnfzheCUNKBcvXmVv5zt6WCs=

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -887,7 +887,6 @@ var EnvironmentSyncFromUserTool = &Tool{
 			return nil, fmt.Errorf("branch is tracking %s, not %s", branchEnv, env.ID)
 		}
 
-		// Use a string builder to capture output
 		patch, err := repo.DiffUserLocalChanges(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate patch: %w", err)

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -137,6 +137,7 @@ func init() {
 		EnvironmentFileReadTool,
 		EnvironmentFileListTool,
 		EnvironmentFileWriteTool,
+		EnvironmentFilePatchTool,
 		EnvironmentFileDeleteTool,
 
 		EnvironmentAddServiceTool,
@@ -610,6 +611,73 @@ var EnvironmentFileWriteTool = &Tool{
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("file %s written successfully and committed to container-use/ remote", targetFile)), nil
+	},
+}
+
+var EnvironmentFilePatchTool = &Tool{
+	Definition: mcp.NewTool("environment_file_patch",
+		mcp.WithDescription("Find and replace text in a file."),
+		mcp.WithString("explanation",
+			mcp.Description("One sentence explanation for why this file is being edited."),
+		),
+		mcp.WithString("environment_source",
+			mcp.Description("Absolute path to the source git repository for the environment."),
+			mcp.Required(),
+		),
+		mcp.WithString("environment_id",
+			mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
+			mcp.Required(),
+		),
+		mcp.WithString("target_file",
+			mcp.Description("Path of the file to write, absolute or relative to the workdir."),
+			mcp.Required(),
+		),
+		mcp.WithString("search_text",
+			mcp.Description("The text to find and replace."),
+			mcp.Required(),
+		),
+		mcp.WithString("replace_text",
+			mcp.Description("The text to insert."),
+			mcp.Required(),
+		),
+		mcp.WithString("which_match",
+			mcp.Description("The ID of the match to replace, if there were multiple matches."),
+		),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		repo, env, err := openEnvironment(ctx, request)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("unable to open the environment", err), nil
+		}
+
+		targetFile, err := request.RequireString("target_file")
+		if err != nil {
+			return nil, err
+		}
+		search, err := request.RequireString("search_text")
+		if err != nil {
+			return nil, err
+		}
+		replace, err := request.RequireString("replace_text")
+		if err != nil {
+			return nil, err
+		}
+
+		if err := env.FileSearchReplace(ctx,
+			request.GetString("explanation", ""),
+			targetFile,
+			search,
+			replace,
+			request.GetString("which_match", ""),
+		); err != nil {
+			return mcp.NewToolResultErrorFromErr("failed to write file", err), nil
+		}
+
+		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+			return mcp.NewToolResultErrorFromErr("unable to update the environment", err), nil
+		}
+
+		return mcp.NewToolResultText(fmt.Sprintf("file %s edited successfully and committed to container-use/ remote", targetFile)), nil
 	},
 }
 

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -867,7 +867,7 @@ var EnvironmentEnableTrackingTool = &Tool{
 var EnvironmentSyncFromUserTool = &Tool{
 	Definition: newEnvironmentTool(
 		"environment_sync_from_user",
-		"Apply the user's unstaged changes to the environment and apply the environment's to the user's local worktree. ONLY RUN WHEN EXPLICITLY REQUESTED BY THE USER.",
+		"Apply the user's unstaged changes to the environment. ONLY RUN WHEN EXPLICITLY REQUESTED BY THE USER.",
 	),
 	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		repo, env, err := openEnvironment(ctx, request)
@@ -899,17 +899,12 @@ var EnvironmentSyncFromUserTool = &Tool{
 			return nil, fmt.Errorf("failed to pull changes to environment: %w", err)
 		}
 
-		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
-			return nil, fmt.Errorf("unable to update the environment: %w", err)
-		}
-
 		if err := repo.ResetUserLocalChanges(ctx); err != nil {
 			return nil, fmt.Errorf("unable to reset user's worktree: %w", err)
 		}
 
-		var buf strings.Builder
-		if err := repo.Apply(ctx, env.ID, &buf); err != nil {
-			return nil, fmt.Errorf("unable to apply changes to user's worktree: %w\n\nlogs:\n%s", err, buf.String())
+		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+			return nil, fmt.Errorf("unable to update the environment: %w", err)
 		}
 
 		return mcp.NewToolResultText("Patch applied successfully to the environment:\n\n```patch\n" + string(patch) + "\n```"), nil

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -283,6 +283,25 @@ func (r *Repository) Update(ctx context.Context, env *environment.Environment, e
 	if err := r.propagateToWorktree(ctx, env, explanation); err != nil {
 		return err
 	}
+
+	// Check if branch tracking is enabled and we're on the tracked branch
+	if env.State.TrackingBranch != "" {
+		currentBranch, err := RunGitCommand(ctx, r.userRepoPath, "branch", "--show-current")
+		if err != nil {
+			// Log the error but don't fail the update
+			slog.Warn("Failed to check current branch for tracking", "error", err)
+		} else {
+			currentBranch = strings.TrimSpace(currentBranch)
+			if currentBranch == env.State.TrackingBranch {
+				// Apply environment changes to the user's working tree
+				if err := r.Apply(ctx, env.ID, io.Discard); err != nil {
+					// Log the error but don't fail the update to avoid breaking the environment
+					slog.Warn("Failed to apply tracking changes to working tree", "error", err, "branch", currentBranch)
+				}
+			}
+		}
+	}
+
 	if note := env.Notes.Pop(); note != "" {
 		return r.addGitNote(ctx, env, note)
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -506,7 +506,7 @@ func (r *Repository) Apply(ctx context.Context, id string, w io.Writer) (rerr er
 }
 
 func (r *Repository) DiffUserLocalChanges(ctx context.Context) (string, error) {
-	diff, err := RunGitCommand(ctx, r.userRepoPath, "diff")
+	diff, err := RunGitCommand(ctx, r.userRepoPath, "diff", "--binary")
 	if err != nil {
 		return "", fmt.Errorf("failed to get user diff: %w", err)
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -144,7 +144,7 @@ func (r *Repository) exists(ctx context.Context, id string) error {
 
 // Create creates a new environment with the given description and explanation.
 // Requires a dagger client for container operations during environment initialization.
-func (r *Repository) Create(ctx context.Context, dag *dagger.Client, description, explanation string) (*environment.Environment, error) {
+func (r *Repository) Create(ctx context.Context, dag *dagger.Client, branch, description, explanation string, ephemeral bool) (*environment.Environment, error) {
 	id := petname.Generate(2, "-")
 	worktree, err := r.initializeWorktree(ctx, id)
 	if err != nil {
@@ -173,7 +173,7 @@ func (r *Repository) Create(ctx context.Context, dag *dagger.Client, description
 		return nil, err
 	}
 
-	env, err := environment.New(ctx, dag, id, description, config, baseSourceDir)
+	env, err := environment.New(ctx, dag, id, branch, description, ephemeral, config, baseSourceDir)
 	if err != nil {
 		return nil, err
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -513,6 +513,26 @@ func (r *Repository) DiffUserLocalChanges(ctx context.Context) (string, error) {
 	return diff, nil
 }
 
+func (r *Repository) TrackEnvironment(ctx context.Context, branch, envID string) error {
+	_, err := RunGitCommand(ctx, r.userRepoPath, "config", "branch."+branch+".environment", envID)
+	if err != nil {
+		return fmt.Errorf("failed to set branch tracking env: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) TrackedEnvironment(ctx context.Context, branch string) (string, error) {
+	envID, err := RunGitCommand(ctx, r.userRepoPath, "config", "get", "--default=", "branch."+branch+".environment")
+	if err != nil {
+		return "", fmt.Errorf("failed to get branch tracking env: %w", err)
+	}
+	envID = strings.TrimSpace(envID)
+	if envID == "" {
+		return "", fmt.Errorf("branch %s is not tracking an environment", branch)
+	}
+	return envID, nil
+}
+
 func (r *Repository) ResetUserLocalChanges(ctx context.Context) error {
 	if _, err := RunGitCommand(ctx, r.userRepoPath, "restore", "."); err != nil {
 		return fmt.Errorf("failed to reset unstaged changes: %w", err)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -471,30 +471,13 @@ func (r *Repository) Apply(ctx context.Context, id string, w io.Writer) (rerr er
 	if hasUnstagedChanges {
 		fmt.Fprintf(w, "Restoring user changes...\n")
 
-		// 1. Temporarily commit the agent's changes (if any)
-		if err := RunInteractiveGitCommand(ctx, r.userRepoPath, w,
-			"commit",
-			// it's simpler/safer to just keep this path unconditional than check if there
-			// were staged stuff before, so just allow an empty commit; we'll be
-			// getting rid of it immediately anyway
-			"--allow-empty",
-			"-m", "temp: agent changes (you should not see this)",
-		); err != nil {
+		// 1. Temporarily commit the agent's changes
+		if err := RunInteractiveGitCommand(ctx, r.userRepoPath, w, "commit", "-m", "temp: agent changes"); err != nil {
 			return fmt.Errorf("failed to commit agent changes: %w", err)
 		}
 
-		// 2. Apply the user's patch, using 3-way merge with --check beforehand to
-		// avoid leaving conflict markers
-		var checkOut strings.Builder
-		checkCmd := exec.CommandContext(ctx, "git", "apply", "--3way", "--check", "-")
-		checkCmd.Dir = r.userRepoPath
-		checkCmd.Stdin = strings.NewReader(diffOutput)
-		checkCmd.Stdout = &checkOut
-		checkCmd.Stderr = &checkOut
-		if err := checkCmd.Run(); err != nil {
-			return fmt.Errorf("conflict detected when re-applying user changes:\n%s", checkOut.String())
-		}
-		applyCmd := exec.CommandContext(ctx, "git", "apply", "--3way", "-")
+		// 2. Apply the user's patch
+		applyCmd := exec.CommandContext(ctx, "git", "apply", "-")
 		applyCmd.Dir = r.userRepoPath
 		applyCmd.Stdin = strings.NewReader(diffOutput)
 		applyCmd.Stdout = w


### PR DESCRIPTION
This does two things:

* Enhances `apply` to preserve unstaged changes, through a delicate `git` dance:
	1. `git diff` to collect user's unstaged changes
	2. `git stash create` to make a backup of all changes (_without affecting the stash list_)
	3. `git reset --hard` to switch to a pristine state
	4. `git merge --squash` (no `--autostash`) to pull in the env changes
	5. `git commit -m "temporary commit"` (see later steps)
	6. `git apply` the patch from 1 (but this stages them)
	7. `git reset` to move the user's changes back to unstaged
	8. `git reset --soft HEAD~1` to move the temporary commit into staging
* Adds a new tool, `environment_sync_from_user`, which:
    1. `git diff` to collect the user's unstaged changes as a patch
    2. Applies the patch to the environment, currently using `patch -p1`
        * This is cheating a bit, but it's the second time that I wanted to use `patch` in the environment, IMO it's worth just requiring it in the environment as it's an incredibly common tool with an interface that's just as stable as `sh` which we already depend on.
    3. Does a `cu apply` so that the user's working copy has the changes staged, ready for another sync

## TODO

* [ ] Some way to guarantee that multiple environments won't go haywire and sync from the user unnecessarily
* [x] Continuously sync _to_ the user's worktree (duh) - should be easy ish now that we have a robust `apply`, as long as it's not fundamentally concurrent with user edits (is that even solveable...?)
* [ ] Other safety concerns?
* [ ] Right now this PR is based on my original file-patching PR, since I once again wanted to be able to use `patch -p1` in the environment and it already had the pattern for it.
* [ ] Handle files marked 'binary'
* [x] Handle files being deleted by the user:
```
ERROR: conflict detected when re-applying user changes:
Applied patch to 'tests/test_for_loops.dang' cleanly.
error: tests/test_for_loops_objects.dang: does not exist in index
```