### PR TITLE
docs: jetbrains junie integration

### DIFF
--- a/docs/agent-integrations.mdx
+++ b/docs/agent-integrations.mdx
@@ -494,6 +494,46 @@ Add to `~/.gemini/settings.json` or `.gemini/settings.json`:
   Configuration](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md)
 </Info>
 
+## JetBrains Junie
+
+### Add MCP Configuration
+
+In the settings, under Tools → Junie → MCP Settings add or edit the MCP configuration, or by editing the file `~/.junie/mcp/mcp.json`:
+
+```json
+{
+  "mcpServers":
+  {
+    "container-use": {
+      "command": "container-use",
+      "args": ["stdio"],
+      "env": {},
+      "timeout": 60000
+    }
+  }
+}
+```
+
+<Info>
+    MCP support in Beta starting with Junie plugin `2xx.204.xx`
+</Info>
+
+### Add Agent Rules
+
+Save agent instructions to your project root:
+
+```sh
+mkdir -p ./.junie && curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md > .junie/guidelines.md
+```
+
+<Info>
+    Learn more: [Junie Guidelines](https://www.jetbrains.com/help/junie/customize-guidelines.html)
+</Info>
+
+### Trust MCP Tools (Optional)
+
+In the settings, under Tools → Junie → Action Allowlist: add _MCP Rule_.
+
 ## Verification
 
 After setting up your agent, verify Container Use is working:


### PR DESCRIPTION
MCP support is in beta starting with version `2xx.204.xx` of Junie plugin: https://plugins.jetbrains.com/plugin/26104-jetbrains-junie/versions/stable/795351
