### PR TITLE
document how to hotfix docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,3 +34,31 @@
    - Review and merge the PR to make the release available via Homebrew
 
 The Dagger CI automatically handles building binaries and creating the draft release when tags are pushed.
+
+## Docs Hotfix
+
+For documentation fixes that need to be published without waiting for a full release:
+
+1. **Squash-merge your documentation PR to main via Github**
+
+2. **Get the SHA of the merged commit**
+   ```sh
+   # Copy the SHA of the merged documentation commit
+   git fetch origin main && git log origin/main
+   ```
+
+3. **Cherry-pick the commit onto the docs branch**
+
+   ```sh
+   git checkout docs --
+   git cherry-pick <commit-hash>
+   ```
+
+4. **Push to origin**
+   ```sh
+   git push origin docs
+   ```
+
+5. **Verify publication**
+   - Check [GitHub Commits](https://github.com/dagger/container-use/commits/docs/) to verify the docs were published successfully
+   - The docs site should update automatically once the workflow completes


### PR DESCRIPTION
i'd like a better link to give for the github actions, but for some reason https://github.com/dagger/container-use/actions\?query\=branch%3Adocs is empty for me?

(also the mintlify deploy failed for me because we don't have enough editors... not sure how to work around that.)