### PR TITLE
make an initial commit for each environment 

### DIFF
--- a/repository/git.go
+++ b/repository/git.go
@@ -153,6 +153,13 @@ func (r *Repository) initializeWorktree(ctx context.Context, id string) (string,
 	return worktreePath, nil
 }
 
+// createInitialCommit creates an empty commit with the environment creation message - this prevents multiple environments from overwriting the container-use-state on the parent commit
+func (r *Repository) createInitialCommit(ctx context.Context, worktreePath, id, title string) error {
+	commitMessage := fmt.Sprintf("Create environment %s: %s", id, title)
+	_, err := RunGitCommand(ctx, worktreePath, "commit", "--allow-empty", "-m", commitMessage)
+	return err
+}
+
 func (r *Repository) propagateToWorktree(ctx context.Context, env *environment.Environment, explanation string) (rerr error) {
 	slog.Info("Propagating to worktree...",
 		"environment.id", env.ID,

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -151,6 +151,10 @@ func (r *Repository) Create(ctx context.Context, dag *dagger.Client, description
 		return nil, err
 	}
 
+	if err := r.createInitialCommit(ctx, worktree, id, description); err != nil {
+		return nil, fmt.Errorf("failed to create initial commit: %w", err)
+	}
+
 	worktreeHead, err := RunGitCommand(ctx, worktree, "rev-parse", "HEAD")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
so envs don't overwrite  @each others' container-use-state note.

this isn't something you notice when you're using environments to write code, but if you're playing with env config or debugging, repeatedly creating envs on top of the same `main` commit will start looking like this:

```
cu list
ID                 TITLE                                      CREATED         UPDATED
present-lark       Development environment for container-us…  3 minutes ago   3 minutes ago
hip-hornet         Development environment for container-us…  3 minutes ago   3 minutes ago
clear-seal         Development environment for container-us…  3 minutes ago   3 minutes ago
clever-elf         Development environment for container-us…  3 minutes ago   3 minutes ago
square-lionfish    Development environment for container-us…  3 minutes ago   3 minutes ago
robust-cougar      Development environment for container-us…  3 minutes ago   3 minutes ago
related-mallard    Development environment for container-us…  3 minutes ago   3 minutes ago
ready-raccoon      Development environment for container-us…  3 minutes ago   3 minutes ago
precious-ray       Development environment for container-us…  3 minutes ago   3 minutes ago
infinite-stinkbug  Development environment for container-us…  3 minutes ago   3 minutes ago
noted-fowl         Development environment for container-us…  3 minutes ago   3 minutes ago
fast-albacore      Development environment for container-us…  3 minutes ago   3 minutes ago
immense-panda      Development environment for container-us…  3 minutes ago   3 minutes ago
fit-possum         Development environment for container-us…  3 minutes ago   3 minutes ago
mint-swan          Development environment for container-us…  3 minutes ago   3 minutes ago
many-reindeer      Development environment for container-us…  3 minutes ago   3 minutes ago
intimate-filly     Development environment for container-us…  3 minutes ago   3 minutes ago
excited-sponge     Development environment for container-us…  3 minutes ago   3 minutes ago
harmless-molly     Development environment for container-us…  3 minutes ago   3 minutes ago
assured-salmon     Development environment for container-us…  3 minutes ago   3 minutes ago
helping-penguin    Development environment for container-us…  3 minutes ago   3 minutes ago
```

where all of these environments have overwritten each other 1-by-1 and only the most recent env is actually accessible to anybody.