### PR TITLE
single tenant mode: lock an mcp process to a single environment

### DIFF
--- a/cmd/container-use/stdio.go
+++ b/cmd/container-use/stdio.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var singleTenant bool
+
 var stdioCmd = &cobra.Command{
 	Use:   "stdio",
 	Short: "Start MCP server for agent integration",
@@ -30,10 +32,11 @@ var stdioCmd = &cobra.Command{
 		}
 		defer dag.Close()
 
-		return mcpserver.RunStdioServer(ctx, dag)
+		return mcpserver.RunStdioServer(ctx, dag, singleTenant)
 	},
 }
 
 func init() {
+	stdioCmd.Flags().BoolVar(&singleTenant, "single-tenant", false, "Enable single-tenant mode where environment ID is optional (assumes one session per server)")
 	rootCmd.AddCommand(stdioCmd)
 }

--- a/mcpserver/args.go
+++ b/mcpserver/args.go
@@ -14,6 +14,9 @@ var (
 		mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
 		mcp.Required(),
 	)
+	environmentIDArgumentSingleTenant = mcp.WithString("environment_id",
+		mcp.Description("The ID of the environment for this command. Defaults to implicit environment if not provided."),
+	)
 )
 
 func newRepositoryTool(name string, description string, args ...mcp.ToolOption) mcp.Tool {
@@ -27,12 +30,17 @@ func newRepositoryTool(name string, description string, args ...mcp.ToolOption) 
 	return mcp.NewTool(name, opts...)
 }
 
-func newEnvironmentTool(name string, description string, args ...mcp.ToolOption) mcp.Tool {
+func newEnvironmentTool(name string, description string, singleTenant bool, args ...mcp.ToolOption) mcp.Tool {
+	envIDArg := environmentIDArgument
+	if singleTenant {
+		envIDArg = environmentIDArgumentSingleTenant
+	}
+
 	opts := []mcp.ToolOption{
 		mcp.WithDescription(description),
 		explainationArgument,
 		environmentSourceArgument,
-		environmentIDArgument,
+		envIDArg,
 	}
 	opts = append(opts, args...)
 

--- a/mcpserver/args.go
+++ b/mcpserver/args.go
@@ -14,9 +14,6 @@ var (
 		mcp.Description("The ID of the environment for this command. Must call `environment_create` first."),
 		mcp.Required(),
 	)
-	environmentIDArgumentSingleTenant = mcp.WithString("environment_id",
-		mcp.Description("The ID of the environment for this command. Defaults to implicit environment if not provided."),
-	)
 )
 
 func newRepositoryTool(name string, description string, args ...mcp.ToolOption) mcp.Tool {
@@ -30,19 +27,17 @@ func newRepositoryTool(name string, description string, args ...mcp.ToolOption) 
 	return mcp.NewTool(name, opts...)
 }
 
-func newEnvironmentTool(name string, description string, singleTenant bool, args ...mcp.ToolOption) mcp.Tool {
-	envIDArg := environmentIDArgument
-	if singleTenant {
-		envIDArg = environmentIDArgumentSingleTenant
-	}
-
+func newEnvironmentTool(name string, description string, includeEnvIDArg bool, args ...mcp.ToolOption) mcp.Tool {
 	opts := []mcp.ToolOption{
 		mcp.WithDescription(description),
 		explainationArgument,
 		environmentSourceArgument,
-		envIDArg,
 	}
-	opts = append(opts, args...)
 
+	if includeEnvIDArg {
+		opts = append(opts, environmentIDArgument)
+	}
+
+	opts = append(opts, args...)
 	return mcp.NewTool(name, opts...)
 }

--- a/mcpserver/singletenant.go
+++ b/mcpserver/singletenant.go
@@ -1,0 +1,38 @@
+// Package mcpserver provides single-tenant mode functionality for MCP servers.
+//
+// In single-tenant mode, a single MCP server process is assumed to serve only one
+// chat session. This allows for optimizations where environment_id parameters can
+// be omitted from most tools, with the server maintaining the current environment
+// in memory.
+
+package mcpserver
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	// currentEnvironmentID stores the current environment ID for single-tenant mode
+	// This is per-server-process, not persisted to disk
+	currentEnvironmentID string
+	currentEnvMutex      sync.RWMutex
+)
+
+// getCurrentEnvironmentID returns the current environment ID for single-tenant mode
+func getCurrentEnvironmentID() (string, error) {
+	currentEnvMutex.RLock()
+	defer currentEnvMutex.RUnlock()
+
+	if currentEnvironmentID == "" {
+		return "", fmt.Errorf("no current environment set. Use environment_create or environment_open first")
+	}
+	return currentEnvironmentID, nil
+}
+
+// setCurrentEnvironmentID sets the current environment ID for single-tenant mode
+func setCurrentEnvironmentID(envID string) {
+	currentEnvMutex.Lock()
+	defer currentEnvMutex.Unlock()
+	currentEnvironmentID = envID
+}

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -22,6 +22,8 @@ import (
 
 type daggerClientKey struct{}
 
+type singleTenantKey struct{}
+
 func openRepository(ctx context.Context, request mcp.CallToolRequest) (*repository.Repository, error) {
 	source, err := request.RequireString("environment_source")
 	if err != nil {
@@ -39,10 +41,39 @@ func openEnvironment(ctx context.Context, request mcp.CallToolRequest) (*reposit
 	if err != nil {
 		return nil, nil, err
 	}
-	envID, err := request.RequireString("environment_id")
-	if err != nil {
-		return nil, nil, err
+
+	// Check if we're in single-tenant mode
+	singleTenant, _ := ctx.Value(singleTenantKey{}).(bool)
+
+	var envID string
+	if singleTenant {
+		// In single-tenant mode, environment_id is optional
+		envID = request.GetString("environment_id", "")
+		if envID == "" {
+			// No environment ID provided, try to find the implicit one
+			envInfos, err := repo.List(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("unable to list environments: %w", err)
+			}
+
+			switch len(envInfos) {
+			case 0:
+				return nil, nil, fmt.Errorf("no environments found. In single-tenant mode, you must create an environment first using environment_create")
+			case 1:
+				envID = envInfos[0].ID
+			default:
+				return nil, nil, fmt.Errorf("multiple environments found in single-tenant mode. This violates single-tenant assumptions. Please specify environment_id explicitly or clean up environments")
+			}
+		}
+	} else {
+		// In multi-tenant mode, environment_id is required
+		var err error
+		envID, err = request.RequireString("environment_id")
+		if err != nil {
+			return nil, nil, err
+		}
 	}
+
 	dag, ok := ctx.Value(daggerClientKey{}).(*dagger.Client)
 	if !ok {
 		return nil, nil, fmt.Errorf("dagger client not found in context")
@@ -59,15 +90,18 @@ type Tool struct {
 	Handler    server.ToolHandlerFunc
 }
 
-func RunStdioServer(ctx context.Context, dag *dagger.Client) error {
+func RunStdioServer(ctx context.Context, dag *dagger.Client, singleTenant bool) error {
+	// Store single-tenant mode in context for tool handlers
+	ctx = context.WithValue(ctx, singleTenantKey{}, singleTenant)
+
 	s := server.NewMCPServer(
 		"Dagger",
 		"1.0.0",
 		server.WithInstructions(rules.AgentRules),
 	)
 
-	for _, t := range tools {
-		s.AddTool(t.Definition, wrapToolWithClient(t, dag).Handler)
+	for _, t := range createTools(singleTenant) {
+		s.AddTool(t.Definition, wrapToolWithClient(t, dag, singleTenant).Handler)
 	}
 
 	slog.Info("starting server")
@@ -85,16 +119,25 @@ func RunStdioServer(ctx context.Context, dag *dagger.Client) error {
 	return nil
 }
 
-var tools = []*Tool{}
-
-func Tools() []*Tool {
-	return tools
+func createTools(singleTenant bool) []*Tool {
+	return []*Tool{
+		wrapTool(createEnvironmentOpenTool(singleTenant)),
+		wrapTool(createEnvironmentCreateTool(singleTenant)),
+		wrapTool(createEnvironmentUpdateMetadataTool(singleTenant)),
+		wrapTool(createEnvironmentConfigTool(singleTenant)),
+		wrapTool(createEnvironmentListTool(singleTenant)),
+		wrapTool(createEnvironmentRunCmdTool(singleTenant)),
+		wrapTool(createEnvironmentFileReadTool(singleTenant)),
+		wrapTool(createEnvironmentFileListTool(singleTenant)),
+		wrapTool(createEnvironmentFileWriteTool(singleTenant)),
+		wrapTool(createEnvironmentFileDeleteTool(singleTenant)),
+		wrapTool(createEnvironmentAddServiceTool(singleTenant)),
+		wrapTool(createEnvironmentCheckpointTool(singleTenant)),
+	}
 }
 
-func registerTool(tool ...*Tool) {
-	for _, t := range tool {
-		tools = append(tools, wrapTool(t))
-	}
+func Tools() []*Tool {
+	return createTools(false) // Default to multi-tenant mode for backward compatibility
 }
 
 func wrapTool(tool *Tool) *Tool {
@@ -115,34 +158,15 @@ func wrapTool(tool *Tool) *Tool {
 }
 
 // keeping this modular for now. we could move tool registration to RunStdioServer and collapse the 2 wrapTool functions.
-func wrapToolWithClient(tool *Tool, dag *dagger.Client) *Tool {
+func wrapToolWithClient(tool *Tool, dag *dagger.Client, singleTenant bool) *Tool {
 	return &Tool{
 		Definition: tool.Definition,
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx = context.WithValue(ctx, daggerClientKey{}, dag)
+			ctx = context.WithValue(ctx, singleTenantKey{}, singleTenant)
 			return tool.Handler(ctx, request)
 		},
 	}
-}
-
-func init() {
-	registerTool(
-		EnvironmentOpenTool,
-		EnvironmentCreateTool,
-		EnvironmentUpdateMetadataTool,
-		EnvironmentConfigTool,
-
-		EnvironmentRunCmdTool,
-
-		EnvironmentFileReadTool,
-		EnvironmentFileListTool,
-		EnvironmentFileWriteTool,
-		EnvironmentFileDeleteTool,
-
-		EnvironmentAddServiceTool,
-
-		EnvironmentCheckpointTool,
-	)
 }
 
 type EnvironmentResponse struct {
@@ -207,66 +231,70 @@ func EnvironmentInfoToCallResult(envInfo *environment.EnvironmentInfo) (*mcp.Cal
 	return mcp.NewToolResultText(out), nil
 }
 
-var EnvironmentOpenTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_open",
-		"Opens an existing environment. Return format is same as environment_create.",
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		_, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-		return EnvironmentToCallResult(env)
-	},
+func createEnvironmentOpenTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_open",
+			"Opens an existing environment. Return format is same as environment_create.",
+			singleTenant,
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+			return EnvironmentToCallResult(env)
+		},
+	}
 }
 
-var EnvironmentCreateTool = &Tool{
-	Definition: newRepositoryTool(
-		"environment_create",
-		`Creates a new development environment.
+func createEnvironmentCreateTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newRepositoryTool(
+			"environment_create",
+			`Creates a new development environment.
 The environment is the result of a the setups commands on top of the base image.
 Environment configuration is managed by the user via cu config commands.`,
-		mcp.WithString("title",
-			mcp.Description("Short description of the work that is happening in this environment."),
-			mcp.Required(),
+			mcp.WithString("title",
+				mcp.Description("Short description of the work that is happening in this environment."),
+				mcp.Required(),
+			),
 		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, err := openRepository(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-		title, err := request.RequireString("title")
-		if err != nil {
-			return nil, err
-		}
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, err := openRepository(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+			title, err := request.RequireString("title")
+			if err != nil {
+				return nil, err
+			}
 
-		dag, ok := ctx.Value(daggerClientKey{}).(*dagger.Client)
-		if !ok {
-			return nil, fmt.Errorf("dagger client not found in context")
-		}
+			dag, ok := ctx.Value(daggerClientKey{}).(*dagger.Client)
+			if !ok {
+				return nil, fmt.Errorf("dagger client not found in context")
+			}
 
-		env, err := repo.Create(ctx, dag, title, request.GetString("explanation", ""))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create environment: %w", err)
-		}
+			env, err := repo.Create(ctx, dag, title, request.GetString("explanation", ""))
+			if err != nil {
+				return nil, fmt.Errorf("failed to create environment: %w", err)
+			}
 
-		out, err := marshalEnvironment(env)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal environment: %w", err)
-		}
+			out, err := marshalEnvironment(env)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal environment: %w", err)
+			}
 
-		dirty, status, err := repo.IsDirty(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("unable to check if environment is dirty: %w", err)
-		}
+			dirty, status, err := repo.IsDirty(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("unable to check if environment is dirty: %w", err)
+			}
 
-		if !dirty {
-			return mcp.NewToolResultText(out), nil
-		}
+			if !dirty {
+				return mcp.NewToolResultText(out), nil
+			}
 
-		return mcp.NewToolResultText(fmt.Sprintf(`%s
+			return mcp.NewToolResultText(fmt.Sprintf(`%s
 
 CRITICAL: You MUST inform the user that the repository %s has uncommitted changes that are NOT included in this environment. The environment was created from the last committed state only.
 
@@ -274,199 +302,234 @@ Uncommitted changes detected:
 %s
 
 You MUST tell the user: To include these changes in the environment, they need to commit them first using git commands outside the environment.`, out, request.GetString("environment_source", ""), status)), nil
-	},
+		},
+	}
 }
 
-var EnvironmentUpdateMetadataTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_update_metadata",
-		"Update environment metadata such as title. This updates the descriptive information about what work is being done in the environment.",
-		mcp.WithString("title",
-			mcp.Description("Updated title describing the work being done in this environment."),
+func createEnvironmentUpdateMetadataTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_update_metadata",
+			"Update environment metadata such as title. This updates the descriptive information about what work is being done in the environment.",
+			singleTenant,
+			mcp.WithString("title",
+				mcp.Description("Updated title describing the work being done in this environment."),
+			),
 		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
+			}
 
-		// Update title if provided
-		if title := request.GetString("title", ""); title != "" {
-			env.State.Title = title
-		}
+			// Update title if provided
+			if title := request.GetString("title", ""); title != "" {
+				env.State.Title = title
+			}
 
-		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
-			return nil, fmt.Errorf("unable to update the environment: %w", err)
-		}
+			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+				return nil, fmt.Errorf("unable to update the environment: %w", err)
+			}
 
-		out, err := marshalEnvironment(env)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal environment: %w", err)
-		}
-		return mcp.NewToolResultText(fmt.Sprintf("Environment metadata updated successfully.\n%s", out)), nil
-	},
+			out, err := marshalEnvironment(env)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal environment: %w", err)
+			}
+			return mcp.NewToolResultText(fmt.Sprintf("Environment metadata updated successfully.\n%s", out)), nil
+		},
+	}
 }
 
-var EnvironmentConfigTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_config",
-		"Make environment config changes such as base image and setup commands."+
-			"If the environment is missing any tools or instructions, you MUST call this function to update the environment."+
-			"You MUST update the environment with any useful tools. You will be resumed with no other context than the information provided here",
-		mcp.WithObject("config",
-			mcp.Required(),
-			mcp.Properties(map[string]any{
-				"base_image": map[string]any{
-					"type":        "string",
-					"description": "Base image for the environment",
-				},
-				"setup_commands": map[string]any{
-					"type":        "array",
-					"description": "Commands that should be executed on top of the base image to set up the environment. Similar to `RUN` instructions in Dockerfiles.",
-					"items":       map[string]any{"type": "string"},
-				},
-				"envs": map[string]any{
-					"type":        "array",
-					"description": "The environment variables to set (e.g. `[\"FOO=bar\", \"BAZ=qux\"]`).",
-					"items":       map[string]any{"type": "string"},
-				},
-			}),
+func createEnvironmentConfigTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_config",
+			"Make environment config changes such as base image and setup commands."+
+				"If the environment is missing any tools or instructions, you MUST call this function to update the environment."+
+				"You MUST update the environment with any useful tools. You will be resumed with no other context than the information provided here",
+			singleTenant,
+			mcp.WithObject("config",
+				mcp.Required(),
+				mcp.Properties(map[string]any{
+					"base_image": map[string]any{
+						"type":        "string",
+						"description": "Base image for the environment",
+					},
+					"setup_commands": map[string]any{
+						"type":        "array",
+						"description": "Commands that should be executed on top of the base image to set up the environment. Similar to `RUN` instructions in Dockerfiles.",
+						"items":       map[string]any{"type": "string"},
+					},
+					"envs": map[string]any{
+						"type":        "array",
+						"description": "The environment variables to set (e.g. `[\"FOO=bar\", \"BAZ=qux\"]`).",
+						"items":       map[string]any{"type": "string"},
+					},
+				}),
+			),
 		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		updatedConfig := env.State.Config.Copy()
-
-		newConfig, ok := request.GetArguments()["config"].(map[string]any)
-		if !ok {
-			return nil, errors.New("invalid config")
-		}
-
-		if baseImage, ok := newConfig["base_image"].(string); ok {
-			updatedConfig.BaseImage = baseImage
-		}
-
-		if setupCommands, ok := newConfig["setup_commands"].([]any); ok {
-			updatedConfig.SetupCommands = make([]string, len(setupCommands))
-			for i, command := range setupCommands {
-				updatedConfig.SetupCommands[i] = command.(string)
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
 			}
-		}
 
-		if envs, ok := newConfig["envs"].([]any); ok {
-			updatedConfig.Env = make([]string, len(envs))
-			for i, env := range envs {
-				updatedConfig.Env[i] = env.(string)
+			updatedConfig := env.State.Config.Copy()
+
+			newConfig, ok := request.GetArguments()["config"].(map[string]any)
+			if !ok {
+				return nil, errors.New("invalid config")
 			}
-		}
 
-		if err := env.UpdateConfig(ctx, updatedConfig); err != nil {
-			return nil, fmt.Errorf("unable to update the environment: %w", err)
-		}
+			if baseImage, ok := newConfig["base_image"].(string); ok {
+				updatedConfig.BaseImage = baseImage
+			}
 
-		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
-			return nil, fmt.Errorf("failed to update repository: %w", err)
-		}
+			if setupCommands, ok := newConfig["setup_commands"].([]any); ok {
+				updatedConfig.SetupCommands = make([]string, len(setupCommands))
+				for i, command := range setupCommands {
+					updatedConfig.SetupCommands[i] = command.(string)
+				}
+			}
 
-		out, err := marshalEnvironment(env)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal environment: %w", err)
-		}
+			if envs, ok := newConfig["envs"].([]any); ok {
+				updatedConfig.Env = make([]string, len(envs))
+				for i, env := range envs {
+					updatedConfig.Env[i] = env.(string)
+				}
+			}
 
-		message := fmt.Sprintf(`SUCCESS: Configuration successfully applied. Environment has been restarted, all previous commands have been lost.
+			if err := env.UpdateConfig(ctx, updatedConfig); err != nil {
+				return nil, fmt.Errorf("unable to update the environment: %w", err)
+			}
+
+			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+				return nil, fmt.Errorf("failed to update repository: %w", err)
+			}
+
+			out, err := marshalEnvironment(env)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal environment: %w", err)
+			}
+
+			message := fmt.Sprintf(`SUCCESS: Configuration successfully applied. Environment has been restarted, all previous commands have been lost.
 IMPORTANT: The configuration changes are LOCAL to this environment.
 TELL THE USER: To make these changes persistent, they will have to run "cu config import %s"
 
 %s
 `, env.ID, out)
 
-		return mcp.NewToolResultText(message), nil
-	},
+			return mcp.NewToolResultText(message), nil
+		},
+	}
 }
 
-var EnvironmentListTool = &Tool{
-	Definition: newRepositoryTool(
-		"environment_list",
-		"List available environments",
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, err := openRepository(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-		envInfos, err := repo.List(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("invalid source: %w", err)
-		}
+func createEnvironmentListTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newRepositoryTool(
+			"environment_list",
+			"List available environments",
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, err := openRepository(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+			envInfos, err := repo.List(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("invalid source: %w", err)
+			}
 
-		// Convert EnvironmentInfo slice to EnvironmentResponse slice
-		responses := make([]EnvironmentResponse, len(envInfos))
-		for i, envInfo := range envInfos {
-			responses[i] = *environmentResponseFromEnvInfo(envInfo)
-		}
+			// Convert EnvironmentInfo slice to EnvironmentResponse slice
+			responses := make([]EnvironmentResponse, len(envInfos))
+			for i, envInfo := range envInfos {
+				responses[i] = *environmentResponseFromEnvInfo(envInfo)
+			}
 
-		out, err := json.Marshal(responses)
-		if err != nil {
-			return nil, err
-		}
-		return mcp.NewToolResultText(string(out)), nil
-	},
+			out, err := json.Marshal(responses)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(out)), nil
+		},
+	}
 }
 
-var EnvironmentRunCmdTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_run_cmd",
-		"Run a terminal command inside a NEW container within the environment.",
-		mcp.WithString("command",
-			mcp.Description("The terminal command to execute. If empty, the environment's default command is used."),
-		),
-		mcp.WithString("shell",
-			mcp.Description("The shell that will be interpreting this command (default: sh)"),
-		),
-		mcp.WithBoolean("background",
-			mcp.Description(`Run the command in the background
+func createEnvironmentRunCmdTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_run_cmd",
+			"Run a terminal command inside a NEW container within the environment.",
+			singleTenant,
+			mcp.WithString("command",
+				mcp.Description("The terminal command to execute. If empty, the environment's default command is used."),
+			),
+			mcp.WithString("shell",
+				mcp.Description("The shell that will be interpreting this command (default: sh)"),
+			),
+			mcp.WithBoolean("background",
+				mcp.Description(`Run the command in the background
 Must ALWAYS be set for long running command (e.g. http server).
 Failure to do so will result in the tool being stuck, awaiting for the command to finish.`,
+				),
+			),
+			mcp.WithBoolean("use_entrypoint",
+				mcp.Description("Use the image entrypoint, if present, by prepending it to the args."),
+			),
+			mcp.WithArray("ports",
+				mcp.Description("Ports to expose. Only works with background environments. For each port, returns the environment_internal (for use inside environments) and host_external (for use by the user) addresses."),
+				mcp.Items(map[string]any{"type": "number"}),
 			),
 		),
-		mcp.WithBoolean("use_entrypoint",
-			mcp.Description("Use the image entrypoint, if present, by prepending it to the args."),
-		),
-		mcp.WithArray("ports",
-			mcp.Description("Ports to expose. Only works with background environments. For each port, returns the environment_internal (for use inside environments) and host_external (for use by the user) addresses."),
-			mcp.Items(map[string]any{"type": "number"}),
-		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		command := request.GetString("command", "")
-		shell := request.GetString("shell", "sh")
-
-		updateRepo := func() error {
-			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
-				return fmt.Errorf("failed to update repository: %w", err)
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
 			}
-			return nil
-		}
 
-		background := request.GetBool("background", false)
-		if background {
-			ports := []int{}
-			if portList, ok := request.GetArguments()["ports"].([]any); ok {
-				for _, port := range portList {
-					ports = append(ports, int(port.(float64)))
+			command := request.GetString("command", "")
+			shell := request.GetString("shell", "sh")
+
+			updateRepo := func() error {
+				if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+					return fmt.Errorf("failed to update repository: %w", err)
 				}
+				return nil
 			}
-			endpoints, runErr := env.RunBackground(ctx, command, shell, ports, request.GetBool("use_entrypoint", false))
+
+			background := request.GetBool("background", false)
+			if background {
+				ports := []int{}
+				if portList, ok := request.GetArguments()["ports"].([]any); ok {
+					for _, port := range portList {
+						ports = append(ports, int(port.(float64)))
+					}
+				}
+				endpoints, runErr := env.RunBackground(ctx, command, shell, ports, request.GetBool("use_entrypoint", false))
+				// We want to update the repository even if the command failed.
+				if err := updateRepo(); err != nil {
+					return nil, err
+				}
+				if runErr != nil {
+					return nil, fmt.Errorf("failed to run command: %w", runErr)
+				}
+
+				out, err := json.Marshal(endpoints)
+				if err != nil {
+					return nil, err
+				}
+
+				return mcp.NewToolResultText(fmt.Sprintf(`Command started in the background in NEW container. Endpoints are %s
+
+To access from the user's machine: use host_external. To access from other commands in this environment: use environment_internal.
+
+Any changes to the container workdir (%s) WILL NOT be committed to container-use/%s
+
+Background commands are unaffected by filesystem and any other kind of changes. You need to start a new command for changes to take effect.`,
+					string(out), env.State.Config.Workdir, env.ID)), nil
+			}
+
+			stdout, runErr := env.Run(ctx, command, shell, request.GetBool("use_entrypoint", false))
 			// We want to update the repository even if the command failed.
 			if err := updateRepo(); err != nil {
 				return nil, err
@@ -475,270 +538,269 @@ Failure to do so will result in the tool being stuck, awaiting for the command t
 				return nil, fmt.Errorf("failed to run command: %w", runErr)
 			}
 
-			out, err := json.Marshal(endpoints)
+			return mcp.NewToolResultText(fmt.Sprintf("%s\n\nAny changes to the container workdir (%s) have been committed and pushed to container-use/ remote", stdout, env.State.Config.Workdir)), nil
+		},
+	}
+}
+
+func createEnvironmentFileReadTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_file_read",
+			"Read the contents of a file, specifying a line range or the entire file.",
+			singleTenant,
+			mcp.WithString("target_file",
+				mcp.Description("Path of the file to read, absolute or relative to the workdir"),
+				mcp.Required(),
+			),
+			mcp.WithBoolean("should_read_entire_file",
+				mcp.Description("Whether to read the entire file. Defaults to false."),
+			),
+			mcp.WithNumber("start_line_one_indexed_inclusive",
+				mcp.Description("The starting line (1-indexed, inclusive) to read from the file. Must specify both start_line and end_line if not reading entire file."),
+			),
+			mcp.WithNumber("end_line_one_indexed_inclusive",
+				mcp.Description("The ending line (1-indexed, inclusive) to read from the file. Must specify both start_line and end_line if not reading entire file."),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, env, err := openEnvironment(ctx, request)
 			if err != nil {
 				return nil, err
 			}
 
-			return mcp.NewToolResultText(fmt.Sprintf(`Command started in the background in NEW container. Endpoints are %s
-
-To access from the user's machine: use host_external. To access from other commands in this environment: use environment_internal.
-
-Any changes to the container workdir (%s) WILL NOT be committed to container-use/%s
-
-Background commands are unaffected by filesystem and any other kind of changes. You need to start a new command for changes to take effect.`,
-				string(out), env.State.Config.Workdir, env.ID)), nil
-		}
-
-		stdout, runErr := env.Run(ctx, command, shell, request.GetBool("use_entrypoint", false))
-		// We want to update the repository even if the command failed.
-		if err := updateRepo(); err != nil {
-			return nil, err
-		}
-		if runErr != nil {
-			return nil, fmt.Errorf("failed to run command: %w", runErr)
-		}
-
-		return mcp.NewToolResultText(fmt.Sprintf("%s\n\nAny changes to the container workdir (%s) have been committed and pushed to container-use/ remote", stdout, env.State.Config.Workdir)), nil
-	},
-}
-
-var EnvironmentFileReadTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_file_read",
-		"Read the contents of a file, specifying a line range or the entire file.",
-		mcp.WithString("target_file",
-			mcp.Description("Path of the file to read, absolute or relative to the workdir"),
-			mcp.Required(),
-		),
-		mcp.WithBoolean("should_read_entire_file",
-			mcp.Description("Whether to read the entire file. Defaults to false."),
-		),
-		mcp.WithNumber("start_line_one_indexed_inclusive",
-			mcp.Description("The one-indexed line number to start reading from (inclusive)."),
-		),
-		mcp.WithNumber("end_line_one_indexed_inclusive",
-			mcp.Description("The one-indexed line number to end reading at (inclusive)."),
-		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		_, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		targetFile, err := request.RequireString("target_file")
-		if err != nil {
-			return nil, err
-		}
-		shouldReadEntireFile := request.GetBool("should_read_entire_file", false)
-		startLineOneIndexedInclusive := request.GetInt("start_line_one_indexed_inclusive", 0)
-		endLineOneIndexedInclusive := request.GetInt("end_line_one_indexed_inclusive", 0)
-
-		fileContents, err := env.FileRead(ctx, targetFile, shouldReadEntireFile, startLineOneIndexedInclusive, endLineOneIndexedInclusive)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file: %w", err)
-		}
-
-		return mcp.NewToolResultText(fileContents), nil
-	},
-}
-
-var EnvironmentFileListTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_file_list",
-		"List the contents of a directory",
-		mcp.WithString("path",
-			mcp.Description("Path of the directory to list contents of, absolute or relative to the workdir"),
-			mcp.Required(),
-		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		_, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		path, err := request.RequireString("path")
-		if err != nil {
-			return nil, err
-		}
-
-		out, err := env.FileList(ctx, path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list directory: %w", err)
-		}
-
-		return mcp.NewToolResultText(out), nil
-	},
-}
-
-var EnvironmentFileWriteTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_file_write",
-		"Write the contents of a file.",
-		mcp.WithString("target_file",
-			mcp.Description("Path of the file to write, absolute or relative to the workdir."),
-			mcp.Required(),
-		),
-		mcp.WithString("contents",
-			mcp.Description("Full text content of the file you want to write."),
-			mcp.Required(),
-		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		targetFile, err := request.RequireString("target_file")
-		if err != nil {
-			return nil, err
-		}
-		contents, err := request.RequireString("contents")
-		if err != nil {
-			return nil, err
-		}
-
-		if err := env.FileWrite(ctx, request.GetString("explanation", ""), targetFile, contents); err != nil {
-			return nil, fmt.Errorf("failed to write file: %w", err)
-		}
-
-		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
-			return nil, fmt.Errorf("unable to update the environment: %w", err)
-		}
-
-		return mcp.NewToolResultText(fmt.Sprintf("file %s written successfully and committed to container-use/ remote", targetFile)), nil
-	},
-}
-
-var EnvironmentFileDeleteTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_file_delete",
-		"Deletes a file at the specified path.",
-		mcp.WithString("target_file",
-			mcp.Description("Path of the file to delete, absolute or relative to the workdir."),
-			mcp.Required(),
-		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		targetFile, err := request.RequireString("target_file")
-		if err != nil {
-			return nil, err
-		}
-
-		if err := env.FileDelete(ctx, request.GetString("explanation", ""), targetFile); err != nil {
-			return nil, fmt.Errorf("failed to delete file: %w", err)
-		}
-
-		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
-			return nil, fmt.Errorf("failed to update env: %w", err)
-		}
-
-		return mcp.NewToolResultText(fmt.Sprintf("file %s deleted successfully and committed to container-use/ remote", targetFile)), nil
-	},
-}
-
-var EnvironmentCheckpointTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_checkpoint",
-		"Checkpoints an environment in its current state as a container.",
-		mcp.WithString("destination",
-			mcp.Description("Container image destination to checkpoint to (e.g. registry.com/user/image:tag"),
-			mcp.Required(),
-		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		_, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-		destination, err := request.RequireString("destination")
-		if err != nil {
-			return nil, err
-		}
-
-		endpoint, err := env.Checkpoint(ctx, destination)
-		if err != nil {
-			return nil, fmt.Errorf("failed to checkpoint environment: %w", err)
-		}
-		return mcp.NewToolResultText(fmt.Sprintf("Checkpoint pushed to %q. You MUST use the full content addressed (@sha256:...) reference in `docker` commands. The entrypoint is set to `sh`, keep that in mind when giving commands to the container.", endpoint)), nil
-	},
-}
-
-var EnvironmentAddServiceTool = &Tool{
-	Definition: newEnvironmentTool(
-		"environment_add_service",
-		"Add a service to the environment (e.g. database, cache, etc.)",
-		mcp.WithString("name",
-			mcp.Description("The name of the service to start."),
-			mcp.Required(),
-		),
-		mcp.WithString("image",
-			mcp.Description("The image of the service to start."),
-			mcp.Required(),
-		),
-		mcp.WithString("command",
-			mcp.Description("The command to start the service. If not provided the image default command will be used."),
-		),
-		mcp.WithArray("ports",
-			mcp.Description("Ports to expose. For each port, returns the container_internal (for use by environments) and host_external (for use by the user) address."),
-			mcp.Items(map[string]any{"type": "number"}),
-		),
-		mcp.WithArray("envs",
-			mcp.Description("The environment variables to set (e.g. `[\"FOO=bar\", \"BAZ=qux\"]`)."),
-			mcp.Items(map[string]any{"type": "string"}),
-		),
-	),
-	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		repo, env, err := openEnvironment(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-		serviceName, err := request.RequireString("name")
-		if err != nil {
-			return nil, err
-		}
-		image, err := request.RequireString("image")
-		if err != nil {
-			return nil, err
-		}
-		command := request.GetString("command", "")
-		ports := []int{}
-		if portList, ok := request.GetArguments()["ports"].([]any); ok {
-			for _, port := range portList {
-				ports = append(ports, int(port.(float64)))
+			targetFile, err := request.RequireString("target_file")
+			if err != nil {
+				return nil, err
 			}
-		}
 
-		envs := request.GetStringSlice("envs", []string{})
+			shouldReadEntireFile := request.GetBool("should_read_entire_file", false)
+			startLineOneIndexedInclusive := request.GetInt("start_line_one_indexed_inclusive", 0)
+			endLineOneIndexedInclusive := request.GetInt("end_line_one_indexed_inclusive", 0)
 
-		service, err := env.AddService(ctx, request.GetString("explanation", ""), &environment.ServiceConfig{
-			Name:         serviceName,
-			Image:        image,
-			Command:      command,
-			ExposedPorts: ports,
-			Env:          envs,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to add service: %w", err)
-		}
+			fileContents, err := env.FileRead(ctx, targetFile, shouldReadEntireFile, startLineOneIndexedInclusive, endLineOneIndexedInclusive)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file: %w", err)
+			}
 
-		if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
-			return nil, fmt.Errorf("failed to update env: %w", err)
-		}
+			return mcp.NewToolResultText(fileContents), nil
+		},
+	}
+}
 
-		output, err := json.Marshal(service)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal service: %w", err)
-		}
+func createEnvironmentFileListTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_file_list",
+			"List the contents of a directory",
+			singleTenant,
+			mcp.WithString("path",
+				mcp.Description("Path of the directory to list contents of, absolute or relative to the workdir"),
+				mcp.Required(),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
+			}
 
-		return mcp.NewToolResultText(fmt.Sprintf("Service added and started successfully: %s", string(output))), nil
-	},
+			path, err := request.RequireString("path")
+			if err != nil {
+				return nil, err
+			}
+
+			out, err := env.FileList(ctx, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list directory: %w", err)
+			}
+
+			return mcp.NewToolResultText(out), nil
+		},
+	}
+}
+
+func createEnvironmentFileWriteTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_file_write",
+			"Write the contents of a file.",
+			singleTenant,
+			mcp.WithString("target_file",
+				mcp.Description("Path of the file to write, absolute or relative to the workdir."),
+				mcp.Required(),
+			),
+			mcp.WithString("contents",
+				mcp.Description("Full text content of the file you want to write."),
+				mcp.Required(),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+
+			targetFile, err := request.RequireString("target_file")
+			if err != nil {
+				return nil, err
+			}
+
+			contents, err := request.RequireString("contents")
+			if err != nil {
+				return nil, err
+			}
+
+			if err := env.FileWrite(ctx, request.GetString("explanation", ""), targetFile, contents); err != nil {
+				return nil, fmt.Errorf("failed to write file: %w", err)
+			}
+
+			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+				return nil, fmt.Errorf("unable to update the environment: %w", err)
+			}
+
+			return mcp.NewToolResultText(fmt.Sprintf("file %s written successfully and committed to container-use/ remote", targetFile)), nil
+		},
+	}
+}
+
+func createEnvironmentFileDeleteTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_file_delete",
+			"Deletes a file at the specified path.",
+			singleTenant,
+			mcp.WithString("target_file",
+				mcp.Description("Path of the file to delete, absolute or relative to the workdir."),
+				mcp.Required(),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+
+			targetFile, err := request.RequireString("target_file")
+			if err != nil {
+				return nil, err
+			}
+
+			if err := env.FileDelete(ctx, request.GetString("explanation", ""), targetFile); err != nil {
+				return nil, fmt.Errorf("failed to delete file: %w", err)
+			}
+
+			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+				return nil, fmt.Errorf("unable to update the environment: %w", err)
+			}
+
+			return mcp.NewToolResultText(fmt.Sprintf("file %s deleted successfully and committed to container-use/ remote", targetFile)), nil
+		},
+	}
+}
+
+func createEnvironmentCheckpointTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_checkpoint",
+			"Checkpoints an environment in its current state as a container.",
+			!singleTenant,
+			mcp.WithString("destination",
+				mcp.Description("Container image destination to checkpoint to (e.g. registry.com/user/image:tag"),
+				mcp.Required(),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+
+			destination, err := request.RequireString("destination")
+			if err != nil {
+				return nil, err
+			}
+
+			checkpointRef, err := env.Checkpoint(ctx, destination)
+			if err != nil {
+				return nil, fmt.Errorf("failed to checkpoint environment: %w", err)
+			}
+
+			return mcp.NewToolResultText(fmt.Sprintf("Environment successfully checkpointed to: %s", checkpointRef)), nil
+		},
+	}
+}
+
+func createEnvironmentAddServiceTool(singleTenant bool) *Tool {
+	return &Tool{
+		Definition: newEnvironmentTool(
+			"environment_add_service",
+			"Add a service to the environment (e.g. database, cache, etc.)",
+			!singleTenant,
+			mcp.WithString("name",
+				mcp.Description("The name of the service to start."),
+				mcp.Required(),
+			),
+			mcp.WithString("image",
+				mcp.Description("The image of the service to start."),
+				mcp.Required(),
+			),
+			mcp.WithString("command",
+				mcp.Description("The command to start the service. If not provided the image default command will be used."),
+			),
+			mcp.WithArray("ports",
+				mcp.Description("Ports to expose. For each port, returns the container_internal (for use by environments) and host_external (for use by the user) address."),
+				mcp.Items(map[string]any{"type": "number"}),
+			),
+			mcp.WithArray("envs",
+				mcp.Description("The environment variables to set (e.g. `[\"FOO=bar\", \"BAZ=qux\"]`)."),
+				mcp.Items(map[string]any{"type": "string"}),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			repo, env, err := openEnvironment(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+			serviceName, err := request.RequireString("name")
+			if err != nil {
+				return nil, err
+			}
+			image, err := request.RequireString("image")
+			if err != nil {
+				return nil, err
+			}
+			command := request.GetString("command", "")
+			ports := []int{}
+			if portList, ok := request.GetArguments()["ports"].([]any); ok {
+				for _, port := range portList {
+					ports = append(ports, int(port.(float64)))
+				}
+			}
+
+			envs := request.GetStringSlice("envs", []string{})
+
+			service, err := env.AddService(ctx, request.GetString("explanation", ""), &environment.ServiceConfig{
+				Name:         serviceName,
+				Image:        image,
+				Command:      command,
+				ExposedPorts: ports,
+				Env:          envs,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to add service: %w", err)
+			}
+
+			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+				return nil, fmt.Errorf("failed to update env: %w", err)
+			}
+
+			output, err := json.Marshal(service)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal service: %w", err)
+			}
+
+			return mcp.NewToolResultText(fmt.Sprintf("Service added and started successfully: %s", string(output))), nil
+		},
+	}
 }


### PR DESCRIPTION
this is intended to be an enhancement for claude code and goose where each chat session start all of its mcp servers from scratch. 

when running in single tenant mode, the server has 1 active environment at a time. creating or opening an environment changes the server's active environment. all other env tools don't take environment IDs, they just require that either create or open is called first.

in claude, this is intended to dramatically improve Task performance by removing the need for each Task to start a new environment.