### PR TITLE
fix unicode marshalling of env configuration (preserve &&)

### DIFF
--- a/environment/config.go
+++ b/environment/config.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -125,12 +126,17 @@ func (config *EnvironmentConfig) Save(baseDir string) error {
 		return err
 	}
 
-	data, err := json.MarshalIndent(config, "", "  ")
-	if err != nil {
+	// Use a custom encoder to prevent HTML escaping of characters like &, <, >
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false) // This prevents & from being escaped as \u0026
+
+	if err := encoder.Encode(config); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(path.Join(configPath, environmentFile), data, 0644); err != nil {
+	if err := os.WriteFile(path.Join(configPath, environmentFile), buf.Bytes(), 0644); err != nil {
 		return err
 	}
 

--- a/environment/config_test.go
+++ b/environment/config_test.go
@@ -77,7 +77,7 @@ func TestEnvironmentConfig_Load(t *testing.T) {
 					t.Skip("Skipping permission test as root")
 				}
 				configDir := filepath.Join(dir, ".container-use")
-				require.NoError(t, os.MkdirAll(configDir, 0000))
+				require.NoError(t, os.MkdirAll(configDir, 0755))
 				t.Cleanup(func() { os.Chmod(configDir, 0755) })
 			},
 			expectError: true,
@@ -102,6 +102,51 @@ func TestEnvironmentConfig_Load(t *testing.T) {
 			assert.Equal(t, scenario.expectBaseImage, config.BaseImage)
 			assert.Equal(t, scenario.expectWorkdir, config.Workdir)
 		})
+	}
+}
+
+// TestEnvironmentConfig_PreservesShellOperators tests that shell operators like && are not
+// escaped as unicode sequences when saving and loading configuration
+func TestEnvironmentConfig_PreservesShellOperators(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create a config with shell operators in setup commands
+	originalConfig := &EnvironmentConfig{
+		BaseImage: "ubuntu:24.04",
+		Workdir:   "/workdir",
+		SetupCommands: []string{
+			"apt update && apt install -y python3",
+			"echo 'test' && ls -la",
+			"cd /tmp && wget https://example.com/file.tar.gz && tar -xzf file.tar.gz",
+		},
+	}
+
+	// Save the configuration
+	err := originalConfig.Save(tempDir)
+	require.NoError(t, err)
+
+	// Read the raw JSON file to check for unicode escaping
+	configPath := filepath.Join(tempDir, ".container-use", "environment.json")
+	rawData, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	rawJSON := string(rawData)
+
+	// Check that && is NOT escaped as \u0026\u0026
+	assert.NotContains(t, rawJSON, "\\u0026\\u0026", "Shell operators should not be unicode-escaped in saved JSON")
+	assert.Contains(t, rawJSON, "&&", "Shell operators should be preserved as-is")
+
+	// Load the configuration back
+	loadedConfig := DefaultConfig()
+	err = loadedConfig.Load(tempDir)
+	require.NoError(t, err)
+
+	// Verify that the loaded configuration preserves the shell operators
+	require.Equal(t, len(originalConfig.SetupCommands), len(loadedConfig.SetupCommands))
+	for i, cmd := range originalConfig.SetupCommands {
+		assert.Equal(t, cmd, loadedConfig.SetupCommands[i], "Setup command %d should preserve shell operators", i)
+		assert.Contains(t, loadedConfig.SetupCommands[i], "&&", "Setup command should contain original && operator")
+		assert.NotContains(t, loadedConfig.SetupCommands[i], "\\u0026", "Setup command should not contain unicode-escaped &")
 	}
 }
 


### PR DESCRIPTION
fixes #231 