### PR TITLE
Add Windows deployment support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           version: "latest"
           verb: call
-          args: release --version "${GITHUB_REF#refs/tags/}" --github-token env:RELEASE_GITHUB_TOKEN --github-org-name=${{ github.repository_owner }}
+          args: release --version "${GITHUB_REF#refs/tags/}" --github-token env:RELEASE_GITHUB_TOKEN --github-org-name=${{ github.repository_owner }} --chocolatey-api-key env:CHOCOLATEY_API_KEY
         env:
           RELEASE_GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,0 +1,52 @@
+name: Test Windows
+
+on:
+  push:
+    branches: ['**']
+  workflow_dispatch:
+
+jobs:
+  test-windows:
+    name: Test Windows
+    runs-on: windows-latest
+    env:
+      _EXPERIMENTAL_DAGGER_RUNNER_HOST: ${{ secrets._EXPERIMENTAL_DAGGER_RUNNER_HOST }}
+      DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "test@example.com"
+          git config --global user.name "Test User"
+
+      - name: Install Dagger
+        shell: pwsh
+        run: |
+          choco install dagger -y
+          echo "$Env:ChocolateyInstall\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          
+      - name: Verify Dagger installation
+        shell: pwsh
+        run: dagger version
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v -race ./...
+
+      - name: Build
+        run: go build -v -o container-use.exe ./cmd/container-use
+
+      - name: Smoke test
+        run: |
+          .\container-use.exe version
+          .\container-use.exe --help
+          .\container-use.exe completion powershell

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,9 @@ archives:
     ids:
       - container-use
     name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
     files:
       - README.md
       - LICENSE
@@ -130,6 +133,37 @@ nix:
         --bash <($out/bin/cu completion bash) \
         --fish <($out/bin/cu completion fish) \
         --zsh <($out/bin/cu completion zsh)
+
+# chocolateys:
+#   - name: container-use
+#     ids:
+#       - container-use-archive
+#     owners: Dagger
+#     title: Container Use
+#     authors: Dagger Team
+#     project_url: https://github.com/dagger/container-use
+#     url_template: "https://github.com/dagger/container-use/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+#     icon_url: https://raw.githubusercontent.com/dagger/container-use/main/docs/images/dagger-icon.png
+#     copyright: 2025 Dagger, Inc.
+#     license_url: https://github.com/dagger/container-use/blob/main/LICENSE
+#     require_license_acceptance: false
+#     project_source_url: https://github.com/dagger/container-use
+#     docs_url: https://container-use.com/
+#     bug_tracker_url: https://github.com/dagger/container-use/issues
+#     tags: "container docker mcp agent development cli devtools"
+#     summary: Containerized environments for coding agents
+#     description: |
+#       Container Use provides isolated, containerized environments for AI coding agents using Docker and Git.
+      
+#       Features:
+#       - Isolated environments for AI agents to work safely
+#       - Git-based version control for all changes
+#       - Docker containers for consistent development environments
+#       - Model Context Protocol (MCP) integration
+#       - Support for multiple popular AI coding assistants
+#     release_notes: "https://github.com/dagger/container-use/releases/tag/{{ .Tag }}"
+#     api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+#     skip_publish: auto
 
 checksum:
   name_template: "checksums.txt"

--- a/cmd/container-use/main_suite_test.go
+++ b/cmd/container-use/main_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -20,7 +21,11 @@ var (
 func getContainerUseBinary(t *testing.T) string {
 	binaryPathOnce.Do(func() {
 		t.Log("Building fresh container-use binary...")
-		cmd := exec.Command("go", "build", "-o", "container-use", ".")
+		binaryName := "container-use"
+		if runtime.GOOS == "windows" {
+			binaryName = "container-use.exe"
+		}
+		cmd := exec.Command("go", "build", "-o", binaryName, ".")
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		err := cmd.Run()
@@ -28,7 +33,7 @@ func getContainerUseBinary(t *testing.T) string {
 			t.Fatalf("Failed to build container-use binary: %v", err)
 		}
 
-		abs, err := filepath.Abs("container-use")
+		abs, err := filepath.Abs(binaryName)
 		if err != nil {
 			t.Fatalf("Failed to get absolute path: %v", err)
 		}

--- a/cmd/container-use/main_test.go
+++ b/cmd/container-use/main_test.go
@@ -1,0 +1,60 @@
+package main_test
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Create a short root; on Windows prefer C:\Temp
+	root := shortRoot("cu-stdio")
+	cache := filepath.Join(root, "cache")
+	tmp := filepath.Join(root, "tmp")
+	app := filepath.Join(root, "appdata")
+	lapp := filepath.Join(root, "localappdata")
+	_ = os.MkdirAll(cache, 0o755)
+	_ = os.MkdirAll(tmp, 0o755)
+	_ = os.MkdirAll(app, 0o755)
+	_ = os.MkdirAll(lapp, 0o755)
+
+	// Shared app/data home for all child servers
+	_ = os.Setenv("XDG_CACHE_HOME", cache)
+	if runtime.GOOS == "windows" {
+		_ = os.Setenv("TEMP", tmp)
+		_ = os.Setenv("TMP", tmp)
+		_ = os.Setenv("APPDATA", app)
+		_ = os.Setenv("LOCALAPPDATA", lapp)
+	} else {
+		_ = os.Setenv("TMPDIR", tmp)
+	}
+
+	// Make Git allow long paths without touching system/global config
+	gitcfg := filepath.Join(root, "gitconfig")
+	_ = os.WriteFile(gitcfg, []byte("[core]\nlongpaths = true\n"), 0o644)
+	_ = os.Setenv("GIT_CONFIG_GLOBAL", gitcfg)
+
+	if os.Getenv("TEST_VERBOSE") != "" {
+		slog.Info("stdio test cache configured",
+			"XDG_CACHE_HOME", cache,
+			"TEMP/TMP/TMPDIR", tmp,
+			"APPDATA", app)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(root)
+	os.Exit(code)
+}
+
+func shortRoot(prefix string) string {
+	if runtime.GOOS != "windows" {
+		dir, _ := os.MkdirTemp("", prefix+"-")
+		return dir
+	}
+	base := `C:\Temp`
+	_ = os.MkdirAll(base, 0o755)
+	dir, _ := os.MkdirTemp(base, prefix+"-")
+	return dir
+}

--- a/cmd/container-use/stdio_test.go
+++ b/cmd/container-use/stdio_test.go
@@ -70,7 +70,6 @@ func NewMCPServerProcess(t *testing.T, testName string) *MCPServerProcess {
 	require.NoError(t, err, "Failed to initialize MCP client")
 
 	server := &MCPServerProcess{
-		// cmd is nil because the MCP client manages the child process itself.
 		cmd:        nil,
 		client:     mcpClient,
 		repoDir:    repoDir,
@@ -105,7 +104,6 @@ func serverSandboxEnv(baseEnv []string) ([]string, string) {
 	return env, root
 }
 
-// Make RPCs fail fast instead of hanging for 10m.
 const rpcTimeout = 120 * time.Second
 
 func ctxRPC() (context.Context, context.CancelFunc) {

--- a/cmd/container-use/version_test.go
+++ b/cmd/container-use/version_test.go
@@ -46,7 +46,7 @@ func TestVersionCommand(t *testing.T) {
 
 				// Container runtime output should show one of the supported runtimes
 				// This handles: "Docker 24.0.5", "Podman 4.3.1", "Docker 24.0.5 (daemon not running)", or "not found"
-				assert.Regexp(t, `Container Runtime: ((Docker|Podman|nerdctl|finch) [\d\.]+(v[\d\.]+)?(\s+\(daemon not running\))?|not found)`, output)
+				assert.Regexp(t, `Container Runtime: ((Docker|Podman|nerdctl|finch) ([\d\.]+(v[\d\.]+)?|unknown)(\s+\(daemon not running\))?|not found)`, output)
 			},
 		},
 		{

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -20,7 +20,28 @@ Make sure you have [Docker](https://www.docker.com/get-started) and Git installe
 
   </Tab>
 
-  <Tab title="Shell Script (All Platforms)">
+  <Tab title="Windows">
+
+  <Note>Native Windows support requires Docker Desktop</Note>
+
+  <Tabs>
+    <Tab title="PowerShell Script">
+    ```powershell
+    $u='https://raw.githubusercontent.com/dagger/container-use/main/install.ps1';$d=Join-Path $env:TEMP 'install-container-use.ps1';$o=@{};if((Get-Command Invoke-WebRequest).Parameters.ContainsKey('UseBasicParsing')){$o.UseBasicParsing=$true};Invoke-WebRequest -Uri $u -OutFile $d @o;& $d -AddToPath
+    ```
+    </Tab>
+    
+    <Tab title="Chocolatey">
+    ```powershell
+    # Available after first release with Windows support
+    choco install container-use
+    ```
+    </Tab>
+  </Tabs>
+
+  </Tab>
+
+  <Tab title="Shell Script (Linux/macOS)">
 
   ```sh
   curl -fsSL https://raw.githubusercontent.com/dagger/container-use/main/install.sh | bash

--- a/environment/integration/testmain_test.go
+++ b/environment/integration/testmain_test.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestMain isolates cache/temp per test process to avoid Dagger cache races on Windows.
+func TestMain(m *testing.M) {
+	// Private sandbox (per process)
+	root, err := os.MkdirTemp("", "cu-test-")
+	if err != nil {
+		panic(err)
+	}
+	cacheHome := filepath.Join(root, "cache")
+	tmpHome := filepath.Join(root, "tmp")
+	if err := os.MkdirAll(cacheHome, 0o755); err != nil {
+		panic(err)
+	}
+	if err := os.MkdirAll(tmpHome, 0o755); err != nil {
+		panic(err)
+	}
+
+	// Dagger respects XDG; temp isolation also helps with path length/locks on Windows.
+	_ = os.Setenv("XDG_CACHE_HOME", cacheHome)
+	if runtime.GOOS == "windows" {
+		_ = os.Setenv("TEMP", tmpHome)
+		_ = os.Setenv("TMP", tmpHome)
+	} else {
+		_ = os.Setenv("TMPDIR", tmpHome)
+	}
+
+	if os.Getenv("TEST_VERBOSE") != "" {
+		slog.Info("using isolated test cache", "XDG_CACHE_HOME", cacheHome, "tmp", tmpHome)
+	}
+
+	code := m.Run()
+
+	// Release file handles before cleanup.
+	if testDaggerClient != nil {
+		_ = testDaggerClient.Close()
+	}
+	_ = os.RemoveAll(root)
+
+	os.Exit(code)
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,307 @@
+#Requires -Version 5.0
+<#
+.Description
+    Download and install container-use.
+
+.PARAMETER Version
+    Version of container-use to install (e.g., v0.4.0). Defaults to latest.
+    Also supports a 7-40 char git commit or "latest".
+
+.PARAMETER DownloadPath
+    Temporary download location seed. The script will place artifacts in the same directory
+    as this temp file. Defaults to a system temp file.
+
+.PARAMETER InstallPath
+    Installation directory. Defaults to $env:USERPROFILE\container-use
+
+.PARAMETER AddToPath
+    If set, add the installation directory to the user's PATH (no elevation required).
+
+.PARAMETER Repo
+    (Advanced) GitHub "owner/repo" to install from. Defaults to dagger/container-use.
+    Useful for testing a fork without editing the script.
+
+.EXAMPLE
+    .\install.ps1
+    Install latest version with default settings.
+
+.EXAMPLE
+    .\install.ps1 -InstallPath "C:\tools\container-use"
+    Install to C:\tools\container-use.
+
+.EXAMPLE
+    .\install.ps1 -Version v0.4.0
+    Install specified version v0.4.0.
+
+.EXAMPLE
+    .\install.ps1 -AddToPath
+    Install and add to PATH.
+
+.EXAMPLE
+    # Install from a fork's releases for testing
+    .\install.ps1 -Repo "grouville/container-use" -Version v0.3.5-test -AddToPath
+#>
+
+Param (
+    [Parameter(Mandatory = $false)]
+    [ValidatePattern('^(latest|v?\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?|[a-f0-9]{7,40})$')]
+    [string]$Version = "latest",
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DownloadPath = [System.IO.Path]::GetTempFileName(),
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$InstallPath = "$env:USERPROFILE\container-use",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AddToPath = $false,
+
+    [Parameter(Mandatory = $false)]
+    [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+    [string]$Repo = "dagger/container-use"
+)
+
+# ---------------------------------------------------------------------------------
+# Container Use Installation Utility for Windows
+# Hardened for PS 5.1 and PS 7+; secure downloads; robust PATH handling
+# ---------------------------------------------------------------------------------
+
+$ErrorActionPreference = "Stop"
+
+# Ensure TLS 1.2 (older Windows can default to TLS 1.0/1.1)
+try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 } catch { }
+
+# Configuration
+$REPO = $Repo
+$BINARY_NAME = "container-use"
+
+# Conditionally supply -UseBasicParsing (PS < 6 supports it; PS 7+ removed it)
+function New-WebArgs {
+    param([Parameter(Mandatory=$true)] [string]$Uri)
+    $args = @{ Uri = $Uri }
+    if ($PSVersionTable.PSVersion.Major -lt 6) { $args.UseBasicParsing = $true }
+    return $args
+}
+
+# Safely append to PATH (User by default), avoiding dupes and empty tails
+function Add-PathEntry {
+    param(
+        [Parameter(Mandatory=$true)] [string]$PathToAdd,
+        [Parameter(Mandatory=$false)] [ValidateSet('User','Machine')] [string]$Scope = 'User'
+    )
+    $cur = [Environment]::GetEnvironmentVariable('Path', $Scope)
+    if (-not $cur) { $cur = '' }
+    $parts = @($cur -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }) + @()
+
+    if ($parts -notcontains $PathToAdd) {
+        $newPath = ($parts + $PathToAdd) -join ';'
+        [Environment]::SetEnvironmentVariable('Path', $newPath, $Scope)
+        Write-Host "Added to $Scope PATH. Restart your terminal to pick it up." -ForegroundColor Green
+    } else {
+        Write-Host "Path already contains $PathToAdd" -ForegroundColor Green
+    }
+}
+
+function Get-ProcessorArchitecture {
+    # Map to Go arch names we ship: amd64, arm64
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        'AMD64' { return 'amd64' }
+        'ARM64' { return 'arm64' }
+        default { throw "Unsupported architecture: $arch (supported: AMD64, ARM64)" }
+    }
+}
+
+function Find-LatestVersion {
+    try {
+        $release = Invoke-RestMethod @((New-WebArgs "https://api.github.com/repos/$REPO/releases/latest")) -UserAgent "PowerShell"
+        return $release.tag_name
+    } catch {
+        throw "Failed to fetch latest release: $_"
+    }
+}
+
+function Get-DownloadUrl {
+    Param (
+        [Parameter(Mandatory = $true)] [string]$Version,
+        [Parameter(Mandatory = $true)] [string]$Arch
+    )
+    # GoReleaser uses the tag (with 'v') in archive names
+    "https://github.com/$REPO/releases/download/$Version/container-use_${Version}_windows_${Arch}.zip"
+}
+
+function Get-ChecksumUrl {
+    Param ([Parameter(Mandatory = $true)] [string]$Version)
+    "https://github.com/$REPO/releases/download/$Version/checksums.txt"
+}
+
+function Get-Checksum {
+    Param (
+        [Parameter(Mandatory = $true)] [string]$Version,
+        [Parameter(Mandatory = $true)] [string]$Arch
+    )
+    $checksumUrl = Get-ChecksumUrl -Version $Version
+    $target = "container-use_${Version}_windows_${Arch}.zip"
+
+    try {
+        $response = Invoke-RestMethod @((New-WebArgs $checksumUrl)) -UserAgent "PowerShell"
+        $checksums = $response -split "`n"
+
+        foreach ($line in $checksums) {
+            if ($line -match [regex]::Escape($target)) {
+                return ($line -split ' ' | Select-Object -First 1)
+            }
+        }
+        throw "Checksum not found for $target"
+    } catch {
+        throw "Failed to fetch or parse checksums: $_"
+    }
+}
+
+function Compare-Checksum {
+    Param (
+        [Parameter(Mandatory = $true)] [string]$FilePath,
+        [Parameter(Mandatory = $true)] [string]$ExpectedChecksum
+    )
+    $hash = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash
+    if ($hash.ToUpperInvariant() -ne $ExpectedChecksum.ToUpperInvariant()) {
+        Remove-Item -Path $FilePath -Force
+        throw "Checksum mismatch. Expected: $ExpectedChecksum, Got: $hash"
+    }
+}
+
+function Get-InstallPath {
+    if (-not (Test-Path $InstallPath)) {
+        New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
+    }
+    return (Get-Item -Path $InstallPath).FullName
+}
+
+function Test-Dependencies {
+    Write-Host "Checking dependencies..." -ForegroundColor Blue
+
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Host "  Docker is required but not installed." -ForegroundColor Red
+        Write-Host "  Install Docker Desktop: https://docs.docker.com/desktop/install/windows-install/" -ForegroundColor Yellow
+        return $false
+    }
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Host "  Git is required but not installed." -ForegroundColor Red
+        Write-Host "  Install Git: https://git-scm.com/download/win" -ForegroundColor Yellow
+        return $false
+    }
+
+    try { docker version *>$null } catch { Write-Host "  Docker is installed but not responding." -ForegroundColor Red; return $false }
+    try { git version    *>$null } catch { Write-Host "  Git is installed but not responding."    -ForegroundColor Red; return $false }
+
+    Write-Host "  Docker is installed" -ForegroundColor Green
+    Write-Host "  Git is installed"    -ForegroundColor Green
+    return $true
+}
+
+function Install-ContainerUse {
+    Write-Host ""
+    Write-Host "Container Use Installer for Windows" -ForegroundColor Cyan
+    Write-Host "===================================" -ForegroundColor Cyan
+    Write-Host ""
+
+    if (-not (Test-Dependencies)) {
+        throw "Missing required dependencies"
+    }
+
+    $targetVersion = $Version
+    if ($targetVersion -eq "latest") {
+        Write-Host "Finding latest version..." -ForegroundColor Blue
+        $targetVersion = Find-LatestVersion
+        Write-Host "Latest version: $targetVersion" -ForegroundColor Green
+    }
+
+    $arch = Get-ProcessorArchitecture
+    Write-Host "Architecture: $arch" -ForegroundColor Blue
+
+    $downloadUrl = Get-DownloadUrl -Version $targetVersion -Arch $arch
+
+    $zipName = "container-use_${targetVersion}_windows_${arch}.zip"
+    $zipPath = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($DownloadPath), $zipName)
+
+    Write-Host "Downloading from $downloadUrl..." -ForegroundColor Blue
+    try {
+        Invoke-WebRequest @((New-WebArgs $downloadUrl)) -OutFile $zipPath
+        Write-Host "Downloaded successfully" -ForegroundColor Green
+    } catch {
+        throw "Failed to download: $_"
+    }
+
+    Write-Host "Verifying checksum..." -ForegroundColor Blue
+    try {
+        $expectedChecksum = Get-Checksum -Version $targetVersion -Arch $arch
+        Compare-Checksum -FilePath $zipPath -ExpectedChecksum $expectedChecksum
+        Write-Host "Checksum verified" -ForegroundColor Green
+    } catch {
+        throw "Checksum verification failed: $_"
+    }
+
+    $tempExtractPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "container-use-extract-$(Get-Random)")
+    Write-Host "Extracting..." -ForegroundColor Blue
+    try {
+        Expand-Archive -Path $zipPath -DestinationPath $tempExtractPath -Force
+    } catch {
+        throw "Failed to extract: $_"
+    } finally {
+        Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+    }
+
+    $installFullPath = Get-InstallPath
+
+    $exePath = Join-Path $tempExtractPath "container-use.exe"
+    if (-not (Test-Path $exePath)) {
+        throw "container-use.exe not found in archive"
+    }
+
+    $destPath = Join-Path $installFullPath "container-use.exe"
+    Copy-Item -Path $exePath -Destination $destPath -Force
+    Write-Host "Installed to $destPath" -ForegroundColor Green
+
+    # Create cu.exe alias for convenience
+    $cuPath = Join-Path $installFullPath "cu.exe"
+    Copy-Item -Path $destPath -Destination $cuPath -Force
+    Write-Host "Created cu.exe alias" -ForegroundColor Green
+
+    # Cleanup
+    Remove-Item $tempExtractPath -Recurse -Force -ErrorAction SilentlyContinue
+
+    # PATH update on request
+    if ($AddToPath) {
+        Add-PathEntry -PathToAdd $installFullPath -Scope 'User'
+    } else {
+        Write-Host ""
+        Write-Host "To add container-use to your PATH, run:" -ForegroundColor Yellow
+        Write-Host "    [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$installFullPath', [EnvironmentVariableTarget]::User)" -ForegroundColor White
+        Write-Host "Or run this script again with -AddToPath" -ForegroundColor Yellow
+    }
+
+    # Verify installation
+    Write-Host ""
+    Write-Host "Verifying installation..." -ForegroundColor Blue
+    try {
+        $versionOutput = (& $destPath version 2>&1 | Out-String).Trim()
+        Write-Host "container-use is ready! Version: $versionOutput" -ForegroundColor Green
+    } catch {
+        Write-Host "container-use installed but couldn't verify version" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "Installation complete!" -ForegroundColor Green
+    Write-Host "Run 'container-use --help' to get started" -ForegroundColor Cyan
+}
+
+# Main execution
+try {
+    Install-ContainerUse
+} catch {
+    Write-Host ""
+    Write-Host "Installation failed: $_" -ForegroundColor Red
+    exit 1
+}

--- a/repository/flock.go
+++ b/repository/flock.go
@@ -69,7 +69,9 @@ func (rlm *RepositoryLockManager) GetLock(lockType LockType) *RepositoryLock {
 		slog.Error("Failed to create lock directory", "path", lockDir, "error", err)
 	}
 
-	lock := &RepositoryLock{flock: flock.New(lockFile)}
+	lock := &RepositoryLock{
+		flock: flock.New(lockFile),
+	}
 	rlm.locks[lockType] = lock
 	return lock
 }

--- a/repository/git.go
+++ b/repository/git.go
@@ -78,9 +78,8 @@ func getContainerUseRemote(ctx context.Context, repo string) (string, error) {
 		}
 		return "", err
 	}
-	cuRemote = strings.TrimSpace(cuRemote)
 
-	return cuRemote, nil
+	return strings.TrimSpace(cuRemote), nil
 }
 
 func (r *Repository) WorktreePath(id string) (string, error) {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -153,16 +153,12 @@ func (r *Repository) ensureUserRemote(ctx context.Context) error {
 			if !errors.Is(err, os.ErrNotExist) {
 				return err
 			}
-			// Convert Windows paths to file:// URLs for git remotes
-			remotePath := r.forkRepoPath
-			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "add", containerUseRemote, remotePath)
+			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "add", containerUseRemote, r.forkRepoPath)
 			return err
 		}
 
 		if currentForkPath != r.forkRepoPath {
-			// Convert Windows paths to file:// URLs for git remotes
-			remotePath := r.forkRepoPath
-			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "set-url", containerUseRemote, remotePath)
+			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "set-url", containerUseRemote, r.forkRepoPath)
 			return err
 		}
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -141,7 +141,8 @@ func (r *Repository) ensureFork(ctx context.Context) error {
 			os.RemoveAll(r.forkRepoPath)
 			return err
 		}
-		return nil
+
+		return r.ensureForkIdentity(ctx)
 	})
 }
 
@@ -152,12 +153,16 @@ func (r *Repository) ensureUserRemote(ctx context.Context) error {
 			if !errors.Is(err, os.ErrNotExist) {
 				return err
 			}
-			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "add", containerUseRemote, r.forkRepoPath)
+			// Convert Windows paths to file:// URLs for git remotes
+			remotePath := r.forkRepoPath
+			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "add", containerUseRemote, remotePath)
 			return err
 		}
 
 		if currentForkPath != r.forkRepoPath {
-			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "set-url", containerUseRemote, r.forkRepoPath)
+			// Convert Windows paths to file:// URLs for git remotes
+			remotePath := r.forkRepoPath
+			_, err := RunGitCommand(ctx, r.userRepoPath, "remote", "set-url", containerUseRemote, remotePath)
 			return err
 		}
 


### PR DESCRIPTION
This is a follow-up of #242, which added Windows compilation but no installation method. This PR completes Windows support by adding:
  - PowerShell installer with checksum verification
  - GoReleaser configuration for Windows .zip archives
  - Chocolatey packaging setup
  - Documentation updates

  ### Testing (outdated, will update below)

  Validated using fork releases:
  ```powershell
  # Test with fork release
  (Invoke-WebRequest "https://raw.githubusercontent.com/grouville/container-use/windows-deployment/install.ps1").Content -replace
  'dagger/container-use', 'grouville/container-use' | Out-File test-install.ps1
  .\test-install.ps1 -Version v0.3.5-test
```

  Next steps

  1. Next release includes Windows binaries
  2. PowerShell installer immediately available
  3. Chocolatey pending API key configuration
  
###  UPDATE 08/18/2025

This is the follow‑up to the earlier “Windows support” work. That PR added the features; this one wires up a Windows pipeline and hardens the pieces that actually run on the host. Because nested virtualization is sketchy on GitHub’s Windows runners (and we don’t want to enable privileged Docker on a public repo), we only exercise the host‑side behavior on Windows. Container execution happens remotely on our runner (via Dagger), so we still get coverage for the CLI, repo plumbing, MCP stdio wiring, and everything else that a Windows user touches locally.

We enable the workflow only on branches in this repo (not forks) and via workflow dispatch.

#### Where the flakes came from (and what we changed)

While bringing the suite up on Windows, we hit a handful of issues that only show up under concurrency:

##### 1. Stalls during MCP stdio Initialize (~10m timeouts).
Multiple stdio servers in the same test process fought over a shared cache and temp directory. On Windows, that turns into rename/lock contention when the Dagger CLI is fetched.
> Fix: give each test process its own cache/tmp sandbox, and then give each MCP server its own sub‑sandbox on top of that. We also bound stdio RPCs with a 120s context so they fail fast instead of hanging.

##### 2. Cross‑process locking wasn’t actually cross‑process.
Once we sandboxed TMP per process, our flock files living under os.TempDir() no longer coordinated across processes.
> Fix: move locks under the container‑use config dir (<config>/locks/...). That restores true cross‑process exclusion regardless of how TMP is isolated.

#####  3. "Author identity unknown" when committing from a fork worktree.
Runners often lack a global Git identity. We only set user.name/email in the source repo during tests, but worktrees commit from the bare fork and don’t inherit that.
> Fix: when we create/ensure the fork, set user.name/email in the bare repo. Copy from the source repo if present, else fall back to container-use / container-use@local. Scope is repo‑local, no global config changes.

##### 4. Path length and odd test names.
Deep temp paths and slashes in subtest names triggered Windows path errors and Git long‑path problems.
> Fix: create temporary roots under a short base (e.g. C:\Temp), sanitize test names, and in cmd/ tests set a temporary global config with core.longpaths=true. We also relaxed a single performance threshold from 2s → 5s on Windows to account for runner slowness.

#### What else is in here

Two small pieces to finish the Windows story:
- Installer + docs: a hardened PowerShell installer (checksums, PS 5.1/7 compatibility, safe PATH updates) and a concise one‑liner in the docs. We also accept “unknown” as a runtime version in a test to match runner reality.
- Release ergonomics: ship Windows artifacts as .zip; wire optional Chocolatey publishing.

#### Logical order of commits

I kept commits logical and readable so you can follow the story:
- CI wiring first, then test isolation (process → server → paths), then repository fixes (locks, fork identity), and finally installer/release bits.

_It might feel over‑isolated, but it’s that combination that made the Windows job green..._