### PR TITLE
feature: allow agent to specify a git ref for environment creation

### DIFF
--- a/environment/integration/helpers.go
+++ b/environment/integration/helpers.go
@@ -228,7 +228,7 @@ func (u *UserActions) RunCommand(envID, command, explanation string) string {
 
 // CreateEnvironment mirrors environment_create MCP tool behavior
 func (u *UserActions) CreateEnvironment(title, explanation string) *environment.Environment {
-	env, err := u.repo.Create(u.ctx, u.dag, title, explanation)
+	env, err := u.repo.Create(u.ctx, u.dag, title, explanation, "HEAD")
 	require.NoError(u.t, err, "Create environment should succeed")
 	return env
 }
@@ -335,4 +335,21 @@ func (u *UserActions) GitCommand(args ...string) string {
 	output, err := repository.RunGitCommand(u.ctx, u.repoDir, args...)
 	require.NoError(u.t, err, "Git command failed: %v", args)
 	return output
+}
+
+// WriteFileInSourceRepo writes a file to the source repo and commits it
+func (u *UserActions) WriteFileInSourceRepo(path, content, commitMessage string) {
+	require.NotEmpty(u.t, u.repoDir, "Need direct access for source file manipulation")
+	writeFile(u.t, u.repoDir, path, content)
+	gitCommit(u.t, u.repoDir, commitMessage)
+}
+
+// CreateBranchInSourceRepo creates and checks out a new branch in the source repo
+func (u *UserActions) CreateBranchInSourceRepo(branchName string) {
+	u.GitCommand("checkout", "-b", branchName)
+}
+
+// CheckoutBranchInSourceRepo checks out an existing branch in the source repo
+func (u *UserActions) CheckoutBranchInSourceRepo(branchName string) {
+	u.GitCommand("checkout", branchName)
 }

--- a/environment/integration/integration_test.go
+++ b/environment/integration/integration_test.go
@@ -379,7 +379,7 @@ func TestWeirdUserScenarios(t *testing.T) {
 		repo1, err := repository.OpenWithBasePath(ctx, repoDir1, configDir1)
 		require.NoError(t, err)
 
-		env1, err := repo1.Create(ctx, testDaggerClient, "App", "Creating app in repo1")
+		env1, err := repo1.Create(ctx, testDaggerClient, "App", "Creating app in repo1", "HEAD")
 		require.NoError(t, err)
 		defer repo1.Delete(ctx, env1.ID)
 

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -276,6 +276,9 @@ func createEnvironmentCreateTool(singleTenant bool) *Tool {
 			mcp.Description("Short description of the work that is happening in this environment."),
 			mcp.Required(),
 		),
+		mcp.WithString("from_git_ref",
+			mcp.Description("Git reference to create the environment from (e.g., HEAD, main, feature-branch, SHA). Defaults to HEAD if not specified."),
+		),
 	}
 
 	// Add allow_replace parameter only in single-tenant mode
@@ -321,7 +324,8 @@ Environment configuration is managed by the user via cu config commands.`,
 				return nil, fmt.Errorf("dagger client not found in context")
 			}
 
-			env, err := repo.Create(ctx, dag, title, request.GetString("explanation", ""))
+			gitRef := request.GetString("from_git_ref", "HEAD")
+			env, err := repo.Create(ctx, dag, title, request.GetString("explanation", ""), gitRef)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create environment: %w", err)
 			}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -181,11 +181,15 @@ func (r *Repository) exists(ctx context.Context, id string) error {
 	return nil
 }
 
-// Create creates a new environment with the given description and explanation.
+// Create creates a new environment with the given description, explanation, and optional git reference.
+// The git reference can be HEAD (default), a SHA, a branch name, or a tag.
 // Requires a dagger client for container operations during environment initialization.
-func (r *Repository) Create(ctx context.Context, dag *dagger.Client, description, explanation string) (*environment.Environment, error) {
+func (r *Repository) Create(ctx context.Context, dag *dagger.Client, description, explanation, gitRef string) (*environment.Environment, error) {
+	if gitRef == "" {
+		gitRef = "HEAD"
+	}
 	id := petname.Generate(2, "-")
-	worktree, err := r.initializeWorktree(ctx, id)
+	worktree, err := r.initializeWorktree(ctx, id, gitRef)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +245,7 @@ func (r *Repository) Get(ctx context.Context, dag *dagger.Client, id string) (*e
 		return nil, err
 	}
 
-	worktree, err := r.initializeWorktree(ctx, id)
+	worktree, err := r.getWorktree(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +271,7 @@ func (r *Repository) Info(ctx context.Context, id string) (*environment.Environm
 		return nil, err
 	}
 
-	worktree, err := r.initializeWorktree(ctx, id)
+	worktree, err := r.getWorktree(ctx, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
this makes it easier to multitask across multiple branches -- you can get the "base" source code from somewhere other than userLocalRepo HEAD meaning that you can change what you've got on HEAD and still safely restart chat sessions that have been prompted to start from a specific SHA. 

corollary to this, we should probably add extra arguments to `cu diff` so that `head` isn't always implied as the base of the diff we're showing... if we persisted this resolved sha, you could even ostensibly have a `--from-source-ref=true` flag that just shows you what the env has added since you started the env... that'd have different content compared to what you get from `cu apply`, so maybe not a good default, but not a bad option to have for best-of-N development.