### PR TITLE
avoid holding locks during Export

### DIFF
--- a/environment/integration/integration_test.go
+++ b/environment/integration/integration_test.go
@@ -183,7 +183,7 @@ func TestSystemHandlesProblematicFiles(t *testing.T) {
 
 // Large project performance ensures the system scales to real-world codebases
 func TestLargeProjectPerformance(t *testing.T) {
-	t.Parallel()
+	// if we had per-repo forkrepo locking, this would be t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping performance test")
 	}

--- a/repository/flock.go
+++ b/repository/flock.go
@@ -16,12 +16,14 @@ import (
 type LockType string
 
 const (
-	// LockTypeRepo - Repository-level operations (fork setup, remote configuration)
-	LockTypeRepo LockType = "repo"
-	// LockTypeWorktree - Worktree operations (branch creation, worktree initialization)
-	LockTypeWorktree LockType = "worktree"
-	// LockTypeGitNotes - Git notes operations (state saves, log updates)
-	LockTypeGitNotes LockType = "notes"
+	// LockTypeUserRepo - Git operations on the environment_source repo (changing remotes, fetching)
+	LockTypeUserRepo LockType = "user-repo"
+	// LockTypeForkRepo - Git operations on our fork (~/.config/container-use/repos/$repo)
+	// Used for committing, creating worktrees, uploading from worktrees (should be rlock for uploads)
+	LockTypeForkRepo LockType = "fork-repo"
+	// LockTypeNotes - Subset of fork repo operations for saving state, notes etc
+	// Notes are a global ref to that repository and we do many operations against them
+	LockTypeNotes LockType = "notes"
 )
 
 // RepositoryLockManager provides granular process-level locking for repository operations

--- a/repository/git.go
+++ b/repository/git.go
@@ -306,10 +306,13 @@ func (r *Repository) addGitNote(ctx context.Context, env *environment.Environmen
 	if err != nil {
 		return fmt.Errorf("failed to get worktree path: %w", err)
 	}
-	_, err = RunGitCommand(ctx, worktreePath, "notes", "--ref", gitNotesLogRef, "append", "-m", note)
-	if err != nil {
+	if err := r.lockManager.WithLock(ctx, LockTypeNotes, func() error {
+		_, err = RunGitCommand(ctx, worktreePath, "notes", "--ref", gitNotesLogRef, "append", "-m", note)
+		return err
+	}); err != nil {
 		return err
 	}
+
 	return r.propagateGitNotes(ctx, gitNotesLogRef)
 }
 

--- a/repository/git.go
+++ b/repository/git.go
@@ -130,7 +130,7 @@ func (r *Repository) initializeWorktree(ctx context.Context, id, gitRef string) 
 
 	slog.Info("Initializing new worktree", "repository", r.userRepoPath, "environment-id", id, "from-ref", gitRef)
 
-	return worktreePath, r.lockManager.WithLock(ctx, LockTypeWorktree, func() error {
+	return worktreePath, r.lockManager.WithLock(ctx, LockTypeForkRepo, func() error {
 		resolvedRef, err := RunGitCommand(ctx, r.userRepoPath, "rev-parse", gitRef)
 		if err != nil {
 			return err

--- a/repository/git_test.go
+++ b/repository/git_test.go
@@ -99,7 +99,9 @@ func TestSelectiveFileStaging(t *testing.T) {
 			scenario.setup(t, dir)
 
 			// Create a Repository instance for testing
-			repo := &Repository{}
+			repo := &Repository{
+				lockManager: NewRepositoryLockManager(dir),
+			}
 
 			// Run the actual staging logic (testing the integration)
 			err = repo.addNonBinaryFiles(ctx, dir)
@@ -141,7 +143,9 @@ func TestCommitWorktreeChanges(t *testing.T) {
 	_, err = RunGitCommand(ctx, dir, "config", "user.name", "Test User")
 	require.NoError(t, err)
 
-	repo := &Repository{}
+	repo := &Repository{
+		lockManager: NewRepositoryLockManager(dir),
+	}
 
 	t.Run("empty_directory_handling", func(t *testing.T) {
 		// Create empty directories (git doesn't track these)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -125,7 +125,7 @@ func OpenWithBasePath(ctx context.Context, repo string, basePath string) (*Repos
 }
 
 func (r *Repository) ensureFork(ctx context.Context) error {
-	return r.lockManager.WithLock(ctx, LockTypeUserRepo, func() error {
+	return r.lockManager.WithLock(ctx, LockTypeForkRepo, func() error {
 		if _, err := os.Stat(r.forkRepoPath); err == nil {
 			return nil
 		} else if !os.IsNotExist(err) {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -229,9 +229,7 @@ func (r *Repository) Create(ctx context.Context, dag *dagger.Client, description
 		return nil, err
 	}
 
-	if err := r.lockManager.WithLock(ctx, LockTypeNotes, func() error {
-		return r.propagateToWorktree(ctx, env, explanation)
-	}); err != nil {
+	if err := r.propagateToWorktree(ctx, env, explanation); err != nil {
 		return nil, err
 	}
 
@@ -368,11 +366,8 @@ func (r *Repository) Update(ctx context.Context, env *environment.Environment, e
 		return err
 	}
 
-	// Handle git notes outside the main propagation to avoid holding locks during export
 	if note := env.Notes.Pop(); note != "" {
-		return r.lockManager.WithLock(ctx, LockTypeNotes, func() error {
-			return r.addGitNote(ctx, env, note)
-		})
+		return r.addGitNote(ctx, env, note)
 	}
 	return nil
 }


### PR DESCRIPTION
Previously we were holding the notes lock for the duration of `Repository.Update(env)`. This meant that running stuff like `cu diff` would block during env_run_cmd. 

This PR tightens that up a bit and makes `cu diff` feel instantaneous again in my testing.

I beat on this heavily using the Contention tests, running 2x5x10 both inside an env and on my host machine and it doesn't reintroduce any data races afaict.