### PR TITLE
chore: fix agent linter instructions so linter output matches CI

### DIFF
--- a/.container-use/environment.json
+++ b/.container-use/environment.json
@@ -7,7 +7,6 @@
     "cd /tmp && curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.18.11 sh && cp ./bin/dagger /usr/local/bin/dagger",
     "git config --global user.name \"Test User\"",
     "git config --global user.email \"test@dagger.com\"",
-    "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.61.0",
     "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
     "apt-get install -y nodejs",
     "npm i -g mint"

--- a/AGENT.md
+++ b/AGENT.md
@@ -13,7 +13,7 @@ DEVELOPMENT WORKFLOW:
 - Build: Use 'go build -o container-use ./cmd/container-use' or 'dagger call build --platform=current export --path ./container-use'
 - Test: Run 'go test ./...' for all tests, 'go test -short ./...' for unit tests only, or 'go test -count=1 -v ./environment' for integration tests
 - Format: Always run 'go fmt ./...' before committing
-- Lint: Run 'golangci-lint run' to check for linting issues
+- Lint: Run 'dagger call lint' to check for linting issues
 - Dependencies: Run 'go mod download' to install dependencies, 'go mod tidy' to clean up
 
 MANUAL STDIO TESTING:


### PR DESCRIPTION
does what it says on the tin -- running `golangci-lint run` directly is way stricter than what we're running in CI and makes the agent generate large diffs when im just trying to get green checks.