### PR TITLE
docs: update Amp integration guide

### DIFF
--- a/docs/agent-integrations.mdx
+++ b/docs/agent-integrations.mdx
@@ -310,8 +310,9 @@ Add this configuration to `~/.config/amp/settings.json`:
             "args": ["stdio"]
         }
     },
-    "amp.commands.allowlist": [],
-    "amp.commands.strict": true,
+    "amp.permissions": [
+      {"tool": "mcp__container-use__*", "action": "allow"}
+    ],
     "amp.dangerouslyAllowAll": false,
     "amp.updates.autoUpdate.enabled": true
 }


### PR DESCRIPTION
With the release of [Permissions](https://ampcode.com/news/tool-level-permissions) the `amp.commands.allowlist` and `amp.commands.strict` settings are gone.