### PR TITLE
upgrade dagger to v0.18.16

### DIFF
--- a/.container-use/environment.json
+++ b/.container-use/environment.json
@@ -4,7 +4,7 @@
   "setup_commands": [
     "apt-get update && apt-get install -y curl git build-essential jq",
     "curl -fsSL https://get.docker.com | sh",
-    "cd /tmp && curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.18.11 sh && cp ./bin/dagger /usr/local/bin/dagger",
+    "cd /tmp && curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.18.16 sh && cp ./bin/dagger /usr/local/bin/dagger",
     "git config --global user.name \"Test User\"",
     "git config --global user.email \"test@dagger.com\"",
     "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "container-use",
-  "engineVersion": "v0.18.14",
+  "engineVersion": "v0.18.16",
   "sdk": {
     "source": "go"
   },

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.24.3
 toolchain go1.24.4
 
 require (
-	dagger.io/dagger v0.18.14
+	dagger.io/dagger v0.18.16
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/fang v0.3.0
 	github.com/charmbracelet/huh v0.7.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
+	github.com/gofrs/flock v0.12.1
 	github.com/mark3labs/mcp-go v0.29.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml/v2 v2.2.4
@@ -43,7 +44,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-dagger.io/dagger v0.18.14 h1:7+VFqNJffm6Qa8ckNRMfsM64sI5dXbRnZswCQ1jnDF0=
-dagger.io/dagger v0.18.14/go.mod h1:azlZ24m2br95t0jQHUBpL5SiafeqtVDLl1Itlq6GO+4=
+dagger.io/dagger v0.18.16 h1:kgrkJ6tMbqnOie1rYjaquEP5sWqqjAUls0b7oUZnMXE=
+dagger.io/dagger v0.18.16/go.mod h1:azlZ24m2br95t0jQHUBpL5SiafeqtVDLl1Itlq6GO+4=
 github.com/99designs/gqlgen v0.17.75 h1:GwHJsptXWLHeY7JO8b7YueUI4w9Pom6wJTICosDtQuI=
 github.com/99designs/gqlgen v0.17.75/go.mod h1:p7gbTpdnHyl70hmSpM8XG8GiKwmCv+T5zkdY8U8bLog=
 github.com/Khan/genqlient v0.8.1 h1:wtOCc8N9rNynRLXN3k3CnfzheCUNKBcvXmVv5zt6WCs=


### PR DESCRIPTION
this should enable other container runtimes amongst other improvements. it does seem to improve blocking behavior a bit, but we're still running into edge merge blocking under stress and continuous use.