### PR TITLE
export 1 file at a time for edits and writes

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -63,6 +63,11 @@ func (env *Environment) Workdir() *dagger.Directory {
 	return env.container().Directory(env.State.Config.Workdir)
 }
 
+// WorkdirFile returns a single file from the workdir
+func (env *Environment) WorkdirFile(path string) *dagger.File {
+	return env.container().File(path)
+}
+
 func (env *Environment) container() *dagger.Container {
 	env.mu.RLock()
 	defer env.mu.RUnlock()

--- a/mcpserver/tools.go
+++ b/mcpserver/tools.go
@@ -742,7 +742,7 @@ func createEnvironmentFileEditTool(singleTenant bool) *Tool {
 				return mcp.NewToolResultErrorFromErr("failed to write file", err), nil
 			}
 
-			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+			if err := repo.UpdateFile(ctx, env, targetFile, request.GetString("explanation", "")); err != nil {
 				return mcp.NewToolResultErrorFromErr("unable to update the environment", err), nil
 			}
 
@@ -787,7 +787,7 @@ func createEnvironmentFileWriteTool(singleTenant bool) *Tool {
 				return nil, fmt.Errorf("failed to write file: %w", err)
 			}
 
-			if err := repo.Update(ctx, env, request.GetString("explanation", "")); err != nil {
+			if err := repo.UpdateFile(ctx, env, targetFile, request.GetString("explanation", "")); err != nil {
 				return nil, fmt.Errorf("unable to update the environment: %w", err)
 			}
 

--- a/repository/git.go
+++ b/repository/git.go
@@ -225,6 +225,11 @@ func (r *Repository) propagateToWorktree(ctx context.Context, env *environment.E
 		return err
 	}
 
+	return r.propagateToGit(ctx, env, explanation)
+}
+
+// propagateToGit commits exported changes and syncs them back to the user's git repository
+func (r *Repository) propagateToGit(ctx context.Context, env *environment.Environment, explanation string) error {
 	worktreePath, err := r.WorktreePath(env.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get worktree path: %w", err)
@@ -253,6 +258,28 @@ func (r *Repository) propagateToWorktree(ctx context.Context, env *environment.E
 	return nil
 }
 
+// propagateFileToWorktree propagates a single file from the environment to the worktree
+// This is more efficient than propagateToWorktree for single file operations
+func (r *Repository) propagateFileToWorktree(ctx context.Context, env *environment.Environment, filePath, explanation string) (rerr error) {
+	slog.Info("Propagating single file to worktree...",
+		"environment.id", env.ID,
+		"file", filePath,
+		"workdir", env.State.Config.Workdir)
+	defer func() {
+		slog.Info("Propagating single file to worktree... (DONE)",
+			"environment.id", env.ID,
+			"file", filePath,
+			"workdir", env.State.Config.Workdir,
+			"err", rerr)
+	}()
+
+	if err := r.exportEnvironmentFile(ctx, env, filePath); err != nil {
+		return err
+	}
+
+	return r.propagateToGit(ctx, env, explanation)
+}
+
 func (r *Repository) exportEnvironment(ctx context.Context, env *environment.Environment) error {
 	worktreePointer := fmt.Sprintf("gitdir: %s", filepath.Join(r.forkRepoPath, "worktrees", env.ID))
 
@@ -270,6 +297,30 @@ func (r *Repository) exportEnvironment(ctx context.Context, env *environment.Env
 		)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// exportEnvironmentFile exports a single file from the environment to the worktree
+func (r *Repository) exportEnvironmentFile(ctx context.Context, env *environment.Environment, filePath string) error {
+	worktreePath, err := r.WorktreePath(env.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get worktree path: %w", err)
+	}
+
+	// Get the absolute path for the file in the worktree
+	absoluteFilePath := filepath.Join(worktreePath, filePath)
+
+	// Ensure the directory exists
+	if err := os.MkdirAll(filepath.Dir(absoluteFilePath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for file %s: %w", filePath, err)
+	}
+
+	// Export the single file from the environment
+	_, err = env.WorkdirFile(filePath).Export(ctx, absoluteFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to export file %s: %w", filePath, err)
 	}
 
 	return nil

--- a/repository/git.go
+++ b/repository/git.go
@@ -255,6 +255,10 @@ func (r *Repository) propagateToGit(ctx context.Context, env *environment.Enviro
 		return err
 	}
 
+	if note := env.Notes.Pop(); note != "" {
+		return r.addGitNote(ctx, env, note)
+	}
+
 	return nil
 }
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -374,6 +374,20 @@ func (r *Repository) Update(ctx context.Context, env *environment.Environment, e
 	return nil
 }
 
+// UpdateFile saves only the specified file from the environment to the repository.
+// This is more efficient than Update() for single file operations as it only exports
+// and commits the specified file instead of the entire directory.
+func (r *Repository) UpdateFile(ctx context.Context, env *environment.Environment, filePath, explanation string) error {
+	if err := r.propagateFileToWorktree(ctx, env, filePath, explanation); err != nil {
+		return err
+	}
+
+	if note := env.Notes.Pop(); note != "" {
+		return r.addGitNote(ctx, env, note)
+	}
+	return nil
+}
+
 // Delete removes an environment from the repository.
 func (r *Repository) Delete(ctx context.Context, id string) error {
 	if err := r.exists(ctx, id); err != nil {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -364,28 +364,14 @@ func (r *Repository) isDescendantOfCommit(ctx context.Context, ancestorCommit, e
 // Update saves the provided environment to the repository.
 // Writes configuration and source code changes to the worktree and history + state to git notes.
 func (r *Repository) Update(ctx context.Context, env *environment.Environment, explanation string) error {
-	if err := r.propagateToWorktree(ctx, env, explanation); err != nil {
-		return err
-	}
-
-	if note := env.Notes.Pop(); note != "" {
-		return r.addGitNote(ctx, env, note)
-	}
-	return nil
+	return r.propagateToWorktree(ctx, env, explanation)
 }
 
 // UpdateFile saves only the specified file from the environment to the repository.
 // This is more efficient than Update() for single file operations as it only exports
 // and commits the specified file instead of the entire directory.
 func (r *Repository) UpdateFile(ctx context.Context, env *environment.Environment, filePath, explanation string) error {
-	if err := r.propagateFileToWorktree(ctx, env, filePath, explanation); err != nil {
-		return err
-	}
-
-	if note := env.Notes.Pop(); note != "" {
-		return r.addGitNote(ctx, env, note)
-	}
-	return nil
+	return r.propagateFileToWorktree(ctx, env, filePath, explanation)
 }
 
 // Delete removes an environment from the repository.


### PR DESCRIPTION
this should speed things up significantly -- now only deletions and run_cmds need to export the whole env directory.