### PR TITLE
expand env vars so PATH setting works as agents expect

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -153,7 +153,9 @@ func containerWithEnvAndSecrets(dag *dagger.Client, container *dagger.Container,
 		if !found {
 			return nil, fmt.Errorf("invalid environment variable: %s", env)
 		}
-		container = container.WithEnvVariable(k, v)
+		container = container.WithEnvVariable(k, v, dagger.ContainerWithEnvVariableOpts{
+			Expand: true,
+		})
 	}
 
 	for _, secret := range secrets {


### PR DESCRIPTION
`envs: [{"PATH": "/usr/lib/go/bin:$PATH"}, ...]`

will break the PATH variable in the container without this lil diff. gonna try to add a test for this before merging.