### PR TITLE
chore(dagger): bump go module pin to fix Wolfi protobuf resolver

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -7,8 +7,8 @@
   "dependencies": [
     {
       "name": "go",
-      "source": "github.com/dagger/dagger/modules/go",
-      "pin": "000dcbce85be95fe5954cda7611efda0bb1bb115"
+      "source": "github.com/dagger/dagger/modules/go@main",
+      "pin": "ce291e358cf9e74f38f7c86972dc6478918513d7"
     },
     {
       "name": "golangci",


### PR DESCRIPTION
Bug: the old dagger go module pin kept the Wolfi base image on protobuf~31, but the repo only serves protobuf 32.x now, so our build died while solving packages.

Fix: bump github.com/dagger/dagger/modules/go to ce291e358cf9e74f38f7c86972dc6478918513d7, which carries the protobuf~32 update and makes the pipeline green again.