### PR TITLE
Update Claude Code integration docs (and fix GitHub URLs)

### DIFF
--- a/docs/agent-integrations.mdx
+++ b/docs/agent-integrations.mdx
@@ -32,13 +32,44 @@ curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md 
 ```
 
 **Trust Only Container Use Tools (Optional):**
-For maximum security, restrict Claude Code to only use Container Use tools:
-```sh
-claude --allowedTools mcp__container-use__environment_add_service,mcp__container-use__environment_checkpoint,mcp__container-use__environment_config,mcp__container-use__environment_create,mcp__container-use__environment_file_delete,mcp__container-use__environment_file_edit,mcp__container-use__environment_file_list,mcp__container-use__environment_file_read,mcp__container-use__environment_file_write,mcp__container-use__environment_open,mcp__container-use__environment_run_cmd,mcp__container-use__environment_update_metadata
+For maximum security, restrict Claude Code to only use Container Use tools by adding the standard tools to the permissions deny list. You may also wish to add Container Use tools to the allow list so that you are not prompted when Claude tries to use them.
+
+In `~/.claude/settings.json` — or one of the other [settings files](https://code.claude.com/docs/en/settings) — add the following configuration:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__container-use__environment_checkpoint",
+      "mcp__container-use__environment_config",
+      "mcp__container-use__environment_create",
+      "mcp__container-use__environment_add_service",
+      "mcp__container-use__environment_file_delete",
+      "mcp__container-use__environment_file_edit",
+      "mcp__container-use__environment_file_list",
+      "mcp__container-use__environment_file_read",
+      "mcp__container-use__environment_file_write",
+      "mcp__container-use__environment_list",
+      "mcp__container-use__environment_open",
+      "mcp__container-use__environment_run_cmd",
+      "mcp__container-use__environment_update_metadata"
+    ],
+    "deny": [
+      "Read",
+      "Write",
+      "Edit",
+      "Bash",
+      "Glob",
+      "Grep",
+      "NotebookEdit",
+      "NotebookRead"
+    ]
+  }
+}
 ```
 
 <Info>
-  Learn more: [Claude Code MCP Documentation](https://docs.anthropic.com/en/docs/claude-code/tutorials#set-up-model-context-protocol-mcp)
+  Learn more: [Claude Code MCP Documentation](https://code.claude.com/docs/en/mcp)
 </Info>
 
 ## Amazon Q Developer

--- a/docs/agent-integrations.mdx
+++ b/docs/agent-integrations.mdx
@@ -28,7 +28,7 @@ claude mcp add container-use -- container-use stdio
 **Add Agent Rules (Optional):**
 Save the CLAUDE.md file at the root of your repository:
 ```sh
-curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md >> CLAUDE.md
+curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md >> CLAUDE.md
 ```
 
 **Trust Only Container Use Tools (Optional):**
@@ -92,7 +92,7 @@ Add this configuration to `~/.aws/amazonq/mcp.json`:
 **Add Agent Rules:**
 Save agent instructions to your project root:
 ```sh
-mkdir -p ./.amazonq/rules && curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md > .amazonq/rules/container-use.md
+mkdir -p ./.amazonq/rules && curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md > .amazonq/rules/container-use.md
 ```
 
 **Trust Only Container Use Tools (Optional):**
@@ -117,7 +117,7 @@ Use the one-click deeplink to install (requires Cursor and Container Use already
 Add the rules file to your project or home directory:
 
 ```sh
-curl --create-dirs -o .cursor/rules/container-use.mdc https://raw.githubusercontent.com/dagger/container-use/main/rules/cursor.mdc
+curl --create-dirs -o .cursor/rules/container-use.mdc https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/cursor.mdc
 ```
 
 <Info>
@@ -148,7 +148,7 @@ In `~/.codeium/windsurf/mcp_config.json`, add the following configuration:
 Add the rules file to your project or home directory:
 
 ```sh
-curl --create-dirs -o .windsurf/rules/container-use.mdc https://raw.githubusercontent.com/dagger/container-use/main/rules/windsurf.mdc
+curl --create-dirs -o .windsurf/rules/container-use.mdc https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/windsurf.mdc
 ```
 
 ## VSCode / GitHub Copilot
@@ -172,7 +172,7 @@ Update your VSCode settings with:
 **Add Copilot Instructions (Optional):**
 
 ```sh
-curl --create-dirs -o .github/copilot-instructions.md https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md
+curl --create-dirs -o .github/copilot-instructions.md https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md
 ```
 
 <Card title="Video Tutorial" icon="youtube" href="https://youtu.be/Nz2sOef0gW0">
@@ -191,7 +191,7 @@ curl --create-dirs -o .github/copilot-instructions.md https://raw.githubusercont
 First add the agent rules file, either as `.rules` in the root of your project or as one of the [other acceptable files/locations](https://zed.dev/docs/ai/rules?highlight=agent.md#rules-files).
 
 ```sh
-curl -o .rules https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md
+curl -o .rules https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md
 ```
 
 Then, choose one of the methods to add the Container Use MCP server in Zed:
@@ -285,7 +285,7 @@ Configure the Container Use MCP server:
 Add the `AGENTS.md` file using this command (this is optional but usually provides the best results):
 
 ```sh
-curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md >> AGENTS.md
+curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md >> AGENTS.md
 ```
 
 Run `opencode` and dispatch your agents to complete your tasks!
@@ -352,7 +352,7 @@ Add this configuration to `~/.config/amp/settings.json`:
 **Add Agent Rules:**
 Save agent instructions to your project root:
 ```sh
-curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md >> AGENT.md
+curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md >> AGENT.md
 ```
 
 <Info>Learn more: [Sourcegraph Amp Documentation](https://ampcode.com/manual/)</Info>
@@ -394,7 +394,7 @@ Add this configuration to [a valid location](https://github.com/charmbracelet/cr
 **Add Agent Rules:**
 Save agent instructions to your project root:
 ```sh
-curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md >> CRUSH.md
+curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md >> CRUSH.md
 ```
 
 <Info>Learn more: [Crush project on GitHub](https://github.com/charmbracelet/crush)</Info>
@@ -425,7 +425,7 @@ Add to your Cline MCP server configuration JSON:
 **Add Agent Rules:**
 
 ```sh
-curl --create-dirs -o .clinerules/container-use.md https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md
+curl --create-dirs -o .clinerules/container-use.md https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md
 ```
 
 <Info>Learn more: [Cline Documentation](https://cline.bot/)</Info>
@@ -535,7 +535,7 @@ Instruct Codex to use container-use for all projects:
 
 ```sh
 mkdir -p ~/.codex
-curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md >> ~/.codex/AGENTS.md
+curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md >> ~/.codex/AGENTS.md
 ```
 
 <Info>
@@ -617,7 +617,7 @@ Add or edit the MCP configuration in Settings under Tools → Junie → MCP Sett
 Save agent instructions to your project root:
 
 ```sh
-mkdir -p ./.junie && curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md >> .junie/guidelines.md
+mkdir -p ./.junie && curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md >> .junie/guidelines.md
 ```
 
 <Info>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -23,7 +23,7 @@ Make sure you have [Docker](https://www.docker.com/get-started) and Git installe
   <Tab title="Shell Script (All Platforms)">
 
   ```sh
-  curl -fsSL https://raw.githubusercontent.com/dagger/container-use/main/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/install.sh | bash
   container-use version
   ```
 
@@ -58,7 +58,7 @@ Container Use works with any MCP-compatible agent: Just add `container-use stdio
     Save CLAUDE.md file at the root of your repository:
 
     ```sh
-    curl https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md >> CLAUDE.md
+    curl https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/rules/agent.md >> CLAUDE.md
     ```
   </Step>
 


### PR DESCRIPTION
Packaged into one PR because it was convenient; I’m happy to separate these or change them as you request.

  * **fix: correct Claude Code integration documentation**

    This fixes the link to the MCP documentation and replaces the incorrect documentation about configuring permissions.

  * **fix: correct githubusercontent.com URLs**

    The previous URLs used the old path structure. It redirects to the current path structure, but that doesn’t work with `curl` unless it’s  invoked with the `-L` option.

    Old path:

        https://raw.githubusercontent.com/dagger/container-use/main/...

    New path:

        https://raw.githubusercontent.com/dagger/container-use/refs/heads/main/...