### PR TITLE
fix: enable push options on local bare repo

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -143,6 +143,14 @@ func (r *Repository) ensureFork(ctx context.Context) error {
 			os.RemoveAll(r.forkRepoPath)
 			return err
 		}
+		// Enable push options support so that pushes from user repos with
+		// push.pushOption configured (or git versions that send push options
+		// by default) don't fail with "the receiving end does not support
+		// push options". See https://github.com/dagger/container-use/issues/323
+		if _, err := RunGitCommand(ctx, r.forkRepoPath, "config", "receive.advertisePushOptions", "true"); err != nil {
+			os.RemoveAll(r.forkRepoPath)
+			return err
+		}
 		return nil
 	})
 }

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -64,5 +64,10 @@ func TestRepositoryOpen(t *testing.T) {
 		remote, err := RunGitCommand(ctx, tempDir, "remote", "get-url", "container-use")
 		require.NoError(t, err)
 		assert.Equal(t, repo.forkRepoPath, strings.TrimSpace(remote))
+
+		// Verify push options are enabled on the fork repo (issue #323)
+		pushOpts, err := RunGitCommand(ctx, repo.forkRepoPath, "config", "receive.advertisePushOptions")
+		require.NoError(t, err)
+		assert.Equal(t, "true", strings.TrimSpace(pushOpts))
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes #323: `git push` to the local bare repository fails with `fatal: the receiving end does not support push options` when the user's git config has `push.pushOption` set or when using newer git versions that send push options by default.
- Sets `receive.advertisePushOptions=true` on the bare fork repo during initialization so it accepts push options.
- Adds a test assertion to verify the config is set correctly.

## Test plan

- [x] Existing `TestRepositoryOpen/valid_git_repository` test passes and now also verifies `receive.advertisePushOptions` is set
- [x] `go test -short ./...` passes (pre-existing failures in `TestSelectiveFileStaging` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)