### PR TITLE
fix: prevent path traversal in exportEnvironmentFile

### DIFF
--- a/repository/git.go
+++ b/repository/git.go
@@ -376,6 +376,12 @@ func (r *Repository) exportEnvironmentFile(ctx context.Context, env *environment
 	// Get the absolute path for the file in the worktree
 	absoluteFilePath := filepath.Join(worktreePath, filePath)
 
+	// Validate the resolved path stays within the worktree to prevent path traversal
+	rel, err := filepath.Rel(worktreePath, absoluteFilePath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("path traversal detected: %s resolves outside worktree", filePath)
+	}
+
 	// Ensure the directory exists
 	if err := os.MkdirAll(filepath.Dir(absoluteFilePath), 0755); err != nil {
 		return fmt.Errorf("failed to create directory for file %s: %w", filePath, err)


### PR DESCRIPTION
## Summary

- Fixes a path traversal vulnerability in `exportEnvironmentFile` where user-controlled `target_file` paths containing `..` sequences could write files outside the worktree directory on the host filesystem
- Adds a boundary check using `filepath.Rel` after `filepath.Join` to ensure the resolved path stays within the worktree

Fixes #337

## Test plan

- [x] Verified `go build ./...` compiles successfully
- [x] Verified `go test -short ./...` passes (2 pre-existing failures in `TestSelectiveFileStaging` unrelated to this change)
- [ ] Paths like `../../.bashrc` are rejected with "path traversal detected" error
- [ ] Normal relative paths like `src/main.go` continue to work as expected