### PR TITLE
fix: resolve env:// secret references from host environment

### DIFF
--- a/environment/config_test.go
+++ b/environment/config_test.go
@@ -154,6 +154,41 @@ func TestEnvironmentConfig_PreservesShellOperators(t *testing.T) {
 	}
 }
 
+func TestResolveSecretValue(t *testing.T) {
+	t.Run("env_scheme_resolves_host_variable", func(t *testing.T) {
+		t.Setenv("TEST_SECRET_VALUE", "my-secret-token")
+
+		resolved, isPlaintext, err := resolveSecretValue("MY_SECRET", "env://TEST_SECRET_VALUE")
+		require.NoError(t, err)
+		assert.True(t, isPlaintext)
+		assert.Equal(t, "my-secret-token", resolved)
+	})
+
+	t.Run("env_scheme_errors_when_variable_not_set", func(t *testing.T) {
+		t.Setenv("TEST_UNSET_VAR", "")
+		os.Unsetenv("TEST_UNSET_VAR")
+
+		_, _, err := resolveSecretValue("MY_SECRET", "env://TEST_UNSET_VAR")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TEST_UNSET_VAR")
+		assert.Contains(t, err.Error(), "not set")
+	})
+
+	t.Run("non_env_scheme_passes_through", func(t *testing.T) {
+		resolved, isPlaintext, err := resolveSecretValue("MY_SECRET", "op://vault/item/field")
+		require.NoError(t, err)
+		assert.False(t, isPlaintext)
+		assert.Equal(t, "op://vault/item/field", resolved)
+	})
+
+	t.Run("plain_value_passes_through", func(t *testing.T) {
+		resolved, isPlaintext, err := resolveSecretValue("MY_SECRET", "plain-secret-value")
+		require.NoError(t, err)
+		assert.False(t, isPlaintext)
+		assert.Equal(t, "plain-secret-value", resolved)
+	})
+}
+
 // Test helper functions
 func createInstructionsFile(t *testing.T, dir, content string) {
 	t.Helper()

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -144,14 +145,29 @@ func (env *Environment) apply(ctx context.Context, newState *dagger.Container) e
 	return nil
 }
 
+// resolveSecretValue resolves a secret reference value.
+// If the value has an "env://" prefix, it looks up the referenced
+// environment variable from the host and returns the resolved plaintext
+// along with resolved=true.
+// For other schemes (e.g., "op://", "vault://"), it returns the value
+// unchanged with resolved=false, so the caller can pass it to Dagger's
+// native secret resolution.
+func resolveSecretValue(key, value string) (resolved string, isPlaintext bool, err error) {
+	if envVar, ok := strings.CutPrefix(value, "env://"); ok {
+		plaintext := os.Getenv(envVar)
+		if plaintext == "" {
+			return "", false, fmt.Errorf("secret %s references environment variable %s, but it is not set", key, envVar)
+		}
+		return plaintext, true, nil
+	}
+	return value, false, nil
+}
+
 func containerWithEnvAndSecrets(dag *dagger.Client, container *dagger.Container, envs, secrets []string) (*dagger.Container, error) {
 	for _, env := range envs {
 		k, v, found := strings.Cut(env, "=")
 		if !found {
 			return nil, fmt.Errorf("invalid env variable: %s", env)
-		}
-		if !found {
-			return nil, fmt.Errorf("invalid environment variable: %s", env)
 		}
 		container = container.WithEnvVariable(k, v, dagger.ContainerWithEnvVariableOpts{
 			Expand: true,
@@ -163,7 +179,17 @@ func containerWithEnvAndSecrets(dag *dagger.Client, container *dagger.Container,
 		if !found {
 			return nil, fmt.Errorf("invalid secret: %s", secret)
 		}
-		container = container.WithSecretVariable(k, dag.Secret(v))
+		resolved, isPlaintext, err := resolveSecretValue(k, v)
+		if err != nil {
+			return nil, err
+		}
+		var daggerSecret *dagger.Secret
+		if isPlaintext {
+			daggerSecret = dag.SetSecret(k, resolved)
+		} else {
+			daggerSecret = dag.Secret(resolved)
+		}
+		container = container.WithSecretVariable(k, daggerSecret)
 	}
 
 	return container, nil


### PR DESCRIPTION
## Summary

- Fixes `env://` secret references not being resolved when creating container environments. The `env://` scheme was passed directly to Dagger's `Secret()` API which does not support it, causing the referenced host environment variable to be unavailable inside containers.
- Adds a `resolveSecretValue()` helper that reads `env://` references from the host's environment and injects them via `dag.SetSecret()`, while other schemes (`op://`, `vault://`) continue to use Dagger's native `dag.Secret()` resolution.
- Includes unit tests for the resolution logic.

Fixes #330

## Test plan

- [x] Added unit tests for `resolveSecretValue` covering: env:// resolution, missing env var error, op:// passthrough, plain value passthrough
- [x] All existing unit tests pass (`go test -short ./...`)
- [ ] Manual test: set a host env var, configure it as a secret with `env://`, verify it's available inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)