### PR TITLE
Remove 'thinking' tool from Zed built-in tools

### DIFF
--- a/docs/agent-integrations.mdx
+++ b/docs/agent-integrations.mdx
@@ -190,7 +190,6 @@ To lock the Zed agent out of your host system, you can create a dedicated agent 
       "name": "Container Use",
       "tools": {
         "fetch": true,
-        "thinking": true,
         "copy_path": false,
         "find_path": false,
         "delete_path": false,


### PR DESCRIPTION
Zed no longer has a "thinking" tool among the built-in tools:

<img width="848" height="988" alt="image" src="https://github.com/user-attachments/assets/0ad3f762-0a53-4d0b-a5e8-40b4d7924b81" />
