### PR TITLE
fix(container-use): pass source when wrapping terminal command

### DIFF
--- a/cmd/container-use/terminal.go
+++ b/cmd/container-use/terminal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"dagger.io/dagger"
 	"github.com/dagger/container-use/repository"
@@ -46,7 +47,11 @@ container-use terminal`,
 				}
 				return fmt.Errorf("failed to look up dagger binary: %w", err)
 			}
-			return execDaggerRun(daggerBin, append([]string{"dagger", "run"}, os.Args...), os.Environ())
+			sourcePath, err := terminalSourcePath(repo.SourcePath())
+			if err != nil {
+				return fmt.Errorf("failed to determine source path: %w", err)
+			}
+			return execDaggerRun(daggerBin, terminalDaggerRunArgs(os.Args, sourcePath), os.Environ())
 		}
 
 		dag, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
@@ -74,4 +79,12 @@ container-use terminal`,
 
 func init() {
 	rootCmd.AddCommand(terminalCmd)
+}
+
+func terminalSourcePath(source string) (string, error) {
+	return filepath.Abs(source)
+}
+
+func terminalDaggerRunArgs(args []string, source string) []string {
+	return append([]string{"dagger", "run", "--source", source}, args...)
 }

--- a/cmd/container-use/terminal_test.go
+++ b/cmd/container-use/terminal_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminalDaggerRunArgs(t *testing.T) {
+	args := terminalDaggerRunArgs([]string{"container-use", "terminal", "fancy-mammal"}, "/workspace")
+
+	assert.Equal(
+		t,
+		[]string{"dagger", "run", "--source", "/workspace", "container-use", "terminal", "fancy-mammal"},
+		args,
+	)
+}
+
+func TestTerminalSourcePathReturnsAbsolutePath(t *testing.T) {
+	sourcePath, err := terminalSourcePath(".")
+	require.NoError(t, err)
+
+	assert.True(t, filepath.IsAbs(sourcePath))
+	assert.Equal(t, sourcePath, filepath.Clean(sourcePath))
+}

--- a/cmd/container-use/terminal_windows.go
+++ b/cmd/container-use/terminal_windows.go
@@ -9,8 +9,8 @@ import (
 )
 
 func execDaggerRun(daggerBin string, args []string, env []string) error {
-	cmd := exec.Command(daggerBin, args...)
-	cmd.Args = append([]string{"dagger", "run"}, os.Args...)
+	cmd := exec.Command(daggerBin, args[1:]...)
+	cmd.Args = args
 	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Fixes #334\n\n## Summary\n- Use the explicitly opened repository source path for `dagger run --source` in terminal auto-wrap mode, replacing the previous cwd-based lookup.\n- Update Windows terminal wrapper execution so it honors the provided arguments and now passes the generated `--source` argument to the wrapped command correctly.\n\n## Testing\n- go test ./cmd/container-use -run TestTerminal -count=1\n- go test -short ./...\n- git diff --check\n