### PR TITLE
Update zed agent-integrations docs

### DIFF
--- a/docs/agent-integrations.mdx
+++ b/docs/agent-integrations.mdx
@@ -157,26 +157,19 @@ curl --create-dirs -o .github/copilot-instructions.md https://raw.githubusercont
 
 ## [Zed](https://zed.dev/)
 
-First add the agent rules file, either as `.rules` in the root of your project or as one of the [other acceptable files/locations](https://zed.dev/docs/ai/rules?highlight=agent.md#rules-files).
-
-```sh
-curl -o .rules https://raw.githubusercontent.com/dagger/container-use/main/rules/agent.md
-```
-
-Then, choose one of the methods to add the Container Use MCP server in Zed:
-
-1. **Extension**: Visit the [Container Use extension page](https://zed.dev/extensions/container-use-mcp-server), open it in Zed, and hit install. Then, follow the configuration instructions that will appear on the modal.
-2. **Settings**: Add the following snippet on your `settings.json`:
+Add the following snippet on your `settings.json`:
 
 ```json
-"context_servers": {
-  "container-use": {
-    "source": "custom",
-    "command": "container-use",
-    "args": ["stdio"],
-    "env": {}
+  "context_servers": {
+    "container-use": {
+      "enabled": true,
+      "remote": false,
+      "command": "container-use",
+      "args": ["stdio"],
+      "env": {},
+      "timeout": 300,
+    },
   },
-}
 ```
 
 **Add Container Use Agent Profile (Optional):**


### PR DESCRIPTION
## Summary

Updates and simplifies the Zed agent integration docs, remove dead links.

I just went through this flow and wasted a lot of time trying to use the zed extension in the zed extension listing. It's no longer maintained and doesn't work (ref: https://github.com/danilo-leal/zed-container-use-mcp/issues/5, etc). 

Adding the extension via settings is easy and works!