### PR TITLE
feat: add GitHub Copilot CLI agent configuration

### DIFF
--- a/cmd/container-use/agent/configure.go
+++ b/cmd/container-use/agent/configure.go
@@ -91,6 +91,8 @@ func selectAgent(agentKey string) (ConfigurableAgent, error) {
 		return &ConfigureCodex{}, nil
 	case "amazonq":
 		return &ConfigureQ{}, nil
+	case "copilot":
+		return &ConfigureCopilot{}, nil
 	}
 	return nil, fmt.Errorf("unknown agent: %s", agentKey)
 }

--- a/cmd/container-use/agent/configure_copilot.go
+++ b/cmd/container-use/agent/configure_copilot.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/dagger/container-use/rules"
+	"github.com/mitchellh/go-homedir"
+)
+
+type ConfigureCopilot struct {
+	Name        string
+	Description string
+}
+
+func NewConfigureCopilot() *ConfigureCopilot {
+	return &ConfigureCopilot{
+		Name:        "GitHub Copilot CLI",
+		Description: "GitHub's AI-powered coding assistant in your terminal",
+	}
+}
+
+// Return the agents full name
+func (a *ConfigureCopilot) name() string {
+	return a.Name
+}
+
+// Return a description of the agent
+func (a *ConfigureCopilot) description() string {
+	return a.Description
+}
+
+// Save the MCP config with container-use enabled
+func (a *ConfigureCopilot) editMcpConfig() error {
+	configPath, err := homedir.Expand(filepath.Join("~", ".copilot", "mcp-config.json"))
+	if err != nil {
+		return err
+	}
+
+	// Create directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	// Read existing config or create new
+	var config map[string]any
+	if data, err := os.ReadFile(configPath); err == nil {
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("failed to parse existing config: %w", err)
+		}
+	} else {
+		config = make(map[string]any)
+	}
+
+	data, err := a.updateMcpConfig(config)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+func (a *ConfigureCopilot) updateMcpConfig(config map[string]any) ([]byte, error) {
+	// Get mcpServers map, preserving any other servers the user already has
+	var mcpServers map[string]any
+	if servers, ok := config["mcpServers"].(map[string]any); ok {
+		mcpServers = servers
+	} else {
+		mcpServers = make(map[string]any)
+		config["mcpServers"] = mcpServers
+	}
+
+	// Add container-use server
+	mcpServers["container-use"] = map[string]any{
+		"type":    "local",
+		"command": ContainerUseBinary,
+		"args":    []any{"stdio"},
+		"tools":   []any{"*"},
+	}
+
+	// Write config back
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config: %w", err)
+	}
+	return data, nil
+}
+
+// Save the agent rules with the container-use prompt
+func (a *ConfigureCopilot) editRules() error {
+	rulesFile := filepath.Join(".github", "copilot-instructions.md")
+	return saveRulesFile(rulesFile, rules.AgentRules)
+}
+
+func (a *ConfigureCopilot) isInstalled() bool {
+	_, err := exec.LookPath("copilot")
+	return err == nil
+}

--- a/cmd/container-use/agent/configure_test.go
+++ b/cmd/container-use/agent/configure_test.go
@@ -102,3 +102,25 @@ func TestConfigureCursorUpdateConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(editedConfig), expect)
 }
+
+func TestConfigureCopilotUpdateConfig(t *testing.T) {
+	copilot := &ConfigureCopilot{}
+	config := make(map[string]any)
+	expect := `{
+  "mcpServers": {
+    "container-use": {
+      "args": [
+        "stdio"
+      ],
+      "command": "container-use",
+      "tools": [
+        "*"
+      ],
+      "type": "local"
+    }
+  }
+}`
+	editedConfig, err := copilot.updateMcpConfig(config)
+	assert.NoError(t, err)
+	assert.Equal(t, string(editedConfig), expect)
+}

--- a/cmd/container-use/agent/configure_ui.go
+++ b/cmd/container-use/agent/configure_ui.go
@@ -43,6 +43,11 @@ var agents = []Agent{
 		Name:        "Amazon Q Developer",
 		Description: "Amazon's agentic chat experience in your terminal (Linux/macOS/WSL)",
 	},
+	{
+		Key:         "copilot",
+		Name:        "GitHub Copilot CLI",
+		Description: "GitHub's AI-powered coding assistant in your terminal",
+	},
 }
 
 // getSupportedAgents returns agents that are supported on the current platform


### PR DESCRIPTION
## What

Adds a first-class `copilot` agent so `container-use config agent copilot` (alias `cu config agent copilot`) configures the GitHub Copilot CLI the same way the existing agents do. Today Copilot is only covered by hand-written MCP docs; this wires it into the same flow as Claude, Cursor, Goose, Codex, and Amazon Q.

## How

New `ConfigureCopilot` implements the existing `ConfigurableAgent` interface:

- `editMcpConfig()` merges the container-use server into `~/.copilot/mcp-config.json` (the user-level config the Copilot CLI reads). It merges into the existing `mcpServers` map so other servers the user already has, including remote ones, are preserved.
- `editRules()` writes the container-use guidance into `.github/copilot-instructions.md`, Copilot's repo-level custom-instructions file, reusing the shared marker-merge helper so it is idempotent and non-destructive.

The agent is registered in the `selectAgent` factory and the interactive picker. Copilot CLI runs on Linux, macOS, and Windows, so it is offered on all platforms.

## Testing (on this machine, copilot v1.0.65)

- `go build ./...`, `go vet ./...`, `gofmt`, and `golangci-lint run` are clean.
- Added `TestConfigureCopilotUpdateConfig` mirroring the existing Cursor/Amazon Q config tests; `go test ./cmd/container-use/agent/` passes.
- Ran the built binary against a throwaway `HOME`: it writes a valid `~/.copilot/mcp-config.json` that `copilot mcp list` and `copilot mcp get container-use` accept, preserves a pre-existing server, and appends the rules block to `.github/copilot-instructions.md` without clobbering existing content.

Relates to #159 (a step toward native Copilot support across platforms: the agent is registered for all platforms).

DCO: commit is signed off.
